### PR TITLE
feat: add named scene routing

### DIFF
--- a/tests/test_scene_store.py
+++ b/tests/test_scene_store.py
@@ -1,0 +1,200 @@
+"""Tests for scene_store — named routing scenes."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from uncommon_route.scene_store import SceneConfig, SceneStore, _serialize_scene, _deserialize_scene
+from uncommon_route.router.types import Tier
+
+
+class TestSceneConfig:
+    def test_model_pool_deduplicates(self):
+        scene = SceneConfig(
+            name="test",
+            primary="anthropic/claude-opus-4.6",
+            fallback=["anthropic/claude-sonnet-4.6", "anthropic/claude-opus-4.6", "openai/gpt-5.2"],
+        )
+        pool = scene.model_pool()
+        assert pool == [
+            "anthropic/claude-opus-4.6",
+            "anthropic/claude-sonnet-4.6",
+            "openai/gpt-5.2",
+        ]
+
+    def test_model_pool_strips_whitespace(self):
+        scene = SceneConfig(name="t", primary=" anthropic/opus ", fallback=[" google/gemini "])
+        pool = scene.model_pool()
+        assert pool == ["anthropic/opus", "google/gemini"]
+
+    def test_model_pool_empty_fallback(self):
+        scene = SceneConfig(name="t", primary="a/b")
+        assert scene.model_pool() == ["a/b"]
+
+    def test_as_routing_constraints(self):
+        scene = SceneConfig(
+            name="test",
+            primary="a/b",
+            fallback=["c/d"],
+            allowed_providers=["anthropic"],
+            max_cost_per_request=0.05,
+        )
+        constraints = scene.as_routing_constraints()
+        assert constraints.allowed_models == ("a/b", "c/d")
+        assert constraints.allowed_providers == ("anthropic",)
+        assert constraints.max_cost == 0.05
+
+    def test_as_selection_weights_none_by_default(self):
+        scene = SceneConfig(name="t", primary="a/b")
+        assert scene.as_selection_weights() is None
+
+    def test_as_selection_weights_override(self):
+        scene = SceneConfig(
+            name="t",
+            primary="a/b",
+            selection_weights_override={"editorial": 0.8, "cost": 0.1},
+        )
+        weights = scene.as_selection_weights()
+        assert weights is not None
+        assert weights.editorial == 0.8
+        assert weights.cost == 0.1
+        # Unspecified fields use defaults
+        assert weights.latency == 0.1
+
+
+class TestSerialization:
+    def test_roundtrip(self):
+        scene = SceneConfig(
+            name="intimate",
+            primary="anthropic/claude-opus-4.6",
+            fallback=["anthropic/claude-sonnet-4.6"],
+            hard_pin=True,
+            description="Private chat with BB",
+            tier_floor=Tier.COMPLEX,
+        )
+        data = _serialize_scene(scene)
+        restored = _deserialize_scene(data)
+        assert restored is not None
+        assert restored.name == "intimate"
+        assert restored.primary == "anthropic/claude-opus-4.6"
+        assert restored.hard_pin is True
+        assert restored.tier_floor == Tier.COMPLEX
+
+    def test_deserialize_invalid_returns_none(self):
+        assert _deserialize_scene({}) is None
+        assert _deserialize_scene({"name": "x"}) is None  # missing primary
+        assert _deserialize_scene({"primary": "x"}) is None  # missing name
+
+    def test_deserialize_normalizes_name(self):
+        scene = _deserialize_scene({"name": "  INTIMATE  ", "primary": "a/b"})
+        assert scene is not None
+        assert scene.name == "intimate"
+
+    def test_tier_enum_serialization(self):
+        scene = SceneConfig(name="t", primary="a/b", tier_floor=Tier.MEDIUM, tier_cap=Tier.COMPLEX)
+        data = _serialize_scene(scene)
+        assert data.get("tier_floor") == "MEDIUM"
+        assert data.get("tier_cap") == "COMPLEX"
+
+
+class TestSceneStore:
+    def _make_store(self, tmp_path: Path) -> SceneStore:
+        return SceneStore(path=tmp_path / "scenes.json")
+
+    def test_add_and_get(self, tmp_path):
+        store = self._make_store(tmp_path)
+        scene = SceneConfig(name="intimate", primary="anthropic/claude-opus-4.6", hard_pin=True)
+        stored = store.add(scene)
+        assert stored.name == "intimate"
+        assert stored.hard_pin is True
+
+        fetched = store.get("intimate")
+        assert fetched is not None
+        assert fetched.primary == "anthropic/claude-opus-4.6"
+
+    def test_get_case_insensitive(self, tmp_path):
+        store = self._make_store(tmp_path)
+        store.add(SceneConfig(name="Intimate", primary="a/b"))
+        assert store.get("intimate") is not None
+        assert store.get("INTIMATE") is not None
+
+    def test_remove(self, tmp_path):
+        store = self._make_store(tmp_path)
+        store.add(SceneConfig(name="test", primary="a/b"))
+        assert store.remove("test") is True
+        assert store.get("test") is None
+        assert store.remove("nonexistent") is False
+
+    def test_list_sorted(self, tmp_path):
+        store = self._make_store(tmp_path)
+        store.add(SceneConfig(name="cron", primary="a/b"))
+        store.add(SceneConfig(name="alpha", primary="c/d"))
+        store.add(SceneConfig(name="work", primary="e/f"))
+        names = [s.name for s in store.list()]
+        assert names == ["alpha", "cron", "work"]
+
+    def test_persistence(self, tmp_path):
+        path = tmp_path / "scenes.json"
+        store1 = SceneStore(path=path)
+        store1.add(SceneConfig(name="intimate", primary="a/opus", hard_pin=True))
+        store1.add(SceneConfig(name="crew", primary="g/flash"))
+
+        # New store instance reads from same file
+        store2 = SceneStore(path=path)
+        assert store2.get("intimate") is not None
+        assert store2.get("intimate").hard_pin is True
+        assert store2.get("crew") is not None
+        assert len(store2.list()) == 2
+
+    def test_add_deduplicates_fallback(self, tmp_path):
+        store = self._make_store(tmp_path)
+        scene = SceneConfig(
+            name="test",
+            primary="a/opus",
+            fallback=["a/sonnet", "a/opus", "a/haiku"],  # opus is duplicate of primary
+        )
+        stored = store.add(scene)
+        assert "a/opus" not in stored.fallback
+        assert stored.fallback == ["a/sonnet", "a/haiku"]
+
+    def test_resolve_missing_returns_none(self, tmp_path):
+        store = self._make_store(tmp_path)
+        assert store.resolve("nonexistent") is None
+
+    def test_resolve_existing_returns_scene(self, tmp_path):
+        store = self._make_store(tmp_path)
+        store.add(SceneConfig(name="intimate", primary="a/b"))
+        resolved = store.resolve("intimate")
+        assert resolved is not None
+        assert resolved.name == "intimate"
+
+    def test_corrupt_file_handled_gracefully(self, tmp_path):
+        path = tmp_path / "scenes.json"
+        path.write_text("not valid json {{{")
+        store = SceneStore(path=path)
+        assert len(store.list()) == 0
+
+    def test_export_import_roundtrip(self, tmp_path):
+        store1 = self._make_store(tmp_path)
+        store1.add(SceneConfig(name="a", primary="x/y"))
+        store1.add(SceneConfig(name="b", primary="z/w", hard_pin=True))
+        exported = store1.export()
+
+        store2 = self._make_store(tmp_path / "other")
+        count = store2.import_scenes(exported)
+        assert count == 2
+        assert store2.get("a") is not None
+        assert store2.get("b").hard_pin is True
+
+    def test_update_existing_scene(self, tmp_path):
+        store = self._make_store(tmp_path)
+        store.add(SceneConfig(name="test", primary="a/b"))
+        store.add(SceneConfig(name="test", primary="c/d", hard_pin=True))
+        scene = store.get("test")
+        assert scene.primary == "c/d"
+        assert scene.hard_pin is True
+        assert len(store.list()) == 1  # Not duplicated

--- a/tests/test_scene_store.py
+++ b/tests/test_scene_store.py
@@ -48,22 +48,10 @@ class TestSceneConfig:
         assert constraints.allowed_providers == ("anthropic",)
         assert constraints.max_cost == 0.05
 
-    def test_as_selection_weights_none_by_default(self):
+    def test_as_selection_weights_returns_none(self):
+        """selection_weights_override removed; method reserved for future use."""
         scene = SceneConfig(name="t", primary="a/b")
         assert scene.as_selection_weights() is None
-
-    def test_as_selection_weights_override(self):
-        scene = SceneConfig(
-            name="t",
-            primary="a/b",
-            selection_weights_override={"editorial": 0.8, "cost": 0.1},
-        )
-        weights = scene.as_selection_weights()
-        assert weights is not None
-        assert weights.editorial == 0.8
-        assert weights.cost == 0.1
-        # Unspecified fields use defaults
-        assert weights.latency == 0.1
 
 
 class TestSerialization:

--- a/uncommon_route/cli.py
+++ b/uncommon_route/cli.py
@@ -1071,6 +1071,116 @@ def _setup_openai(args: list[str]) -> None:
 
 
 
+def _cmd_scene(args: list[str]) -> None:
+    """Manage named routing scenes."""
+    if not args:
+        print("Usage: uncommon-route scene <action>", file=sys.stderr)
+        print("  Actions: list, add, remove, show", file=sys.stderr)
+        sys.exit(1)
+
+    from uncommon_route.scene_store import SceneStore, SceneConfig
+
+    store = SceneStore()
+    action = args[0].lower()
+
+    if action == "list":
+        scenes = store.list()
+        if not scenes:
+            print("No scenes configured.")
+            print("  Add one: uncommon-route scene add intimate anthropic/claude-opus-4.6 --hard-pin")
+            return
+        for scene in scenes:
+            pin_label = " [hard-pin]" if scene.hard_pin else " [adaptive]"
+            desc = f"  ({scene.description})" if scene.description else ""
+            fallback_str = f" → {', '.join(scene.fallback)}" if scene.fallback else ""
+            print(f"  {scene.name}: {scene.primary}{fallback_str}{pin_label}{desc}")
+
+    elif action == "add":
+        if len(args) < 3:
+            print("Usage: uncommon-route scene add <name> <primary> [fallback...] [--hard-pin] [--description 'desc']", file=sys.stderr)
+            sys.exit(1)
+        name = args[1]
+        primary = args[2]
+        fallback = []
+        hard_pin = False
+        description = ""
+        i = 3
+        while i < len(args):
+            if args[i] == "--hard-pin":
+                hard_pin = True
+                i += 1
+            elif args[i] == "--description" and i + 1 < len(args):
+                description = args[i + 1]
+                i += 2
+            elif args[i] == "--fallback":
+                i += 1
+                while i < len(args) and not args[i].startswith("--"):
+                    fallback.append(args[i])
+                    i += 1
+            elif not args[i].startswith("--"):
+                fallback.append(args[i])
+                i += 1
+            else:
+                i += 1
+
+        scene = SceneConfig(
+            name=name,
+            primary=primary,
+            fallback=fallback,
+            hard_pin=hard_pin,
+            description=description,
+        )
+        stored = store.add(scene)
+        pin_label = "hard-pin" if stored.hard_pin else "adaptive"
+        print(f"Scene '{stored.name}' saved: {stored.primary} [{pin_label}]")
+        if stored.fallback:
+            print(f"  Fallback: {', '.join(stored.fallback)}")
+
+    elif action == "remove":
+        if len(args) < 2:
+            print("Usage: uncommon-route scene remove <name>", file=sys.stderr)
+            sys.exit(1)
+        name = args[1]
+        if store.remove(name):
+            print(f"Scene '{name}' removed.")
+        else:
+            print(f"Scene '{name}' not found.", file=sys.stderr)
+            sys.exit(1)
+
+    elif action == "show":
+        if len(args) < 2:
+            print("Usage: uncommon-route scene show <name>", file=sys.stderr)
+            sys.exit(1)
+        name = args[1]
+        scene = store.get(name)
+        if not scene:
+            print(f"Scene '{name}' not found.", file=sys.stderr)
+            sys.exit(1)
+        print(f"Scene: {scene.name}")
+        print(f"  Primary: {scene.primary}")
+        if scene.fallback:
+            print(f"  Fallback: {', '.join(scene.fallback)}")
+        print(f"  Mode: {'hard-pin' if scene.hard_pin else 'adaptive'}")
+        if scene.description:
+            print(f"  Description: {scene.description}")
+        if scene.complexity_override is not None:
+            print(f"  Complexity override: {scene.complexity_override}")
+        if scene.tier_floor:
+            print(f"  Tier floor: {scene.tier_floor.value}")
+        if scene.tier_cap:
+            print(f"  Tier cap: {scene.tier_cap.value}")
+        if scene.allowed_providers:
+            print(f"  Allowed providers: {', '.join(scene.allowed_providers)}")
+        if scene.max_cost_per_request is not None:
+            print(f"  Max cost/req: ${scene.max_cost_per_request:.4f}")
+        print(f"  Model pool: {' → '.join(scene.model_pool())}")
+
+    else:
+        print(f"Unknown scene action: {action}", file=sys.stderr)
+        print("  Actions: list, add, remove, show", file=sys.stderr)
+        sys.exit(1)
+
+
 def main() -> None:
     args = sys.argv[1:]
 
@@ -1099,6 +1209,7 @@ def main() -> None:
         "config": _cmd_config,
         "stats": _cmd_stats,
         "feedback": _cmd_feedback,
+        "scene": _cmd_scene,
     }
 
     handler = commands.get(cmd)

--- a/uncommon_route/proxy.py
+++ b/uncommon_route/proxy.py
@@ -78,6 +78,7 @@ from uncommon_route.providers import (
 )
 from uncommon_route.model_map import ModelMapper
 from uncommon_route.routing_config_store import RoutingConfigStore
+from uncommon_route.scene_store import SceneConfig, SceneStore
 from uncommon_route.connections_store import ConnectionsStore, mask_api_key, resolve_primary_connection
 from uncommon_route.anthropic_compat import (
     anthropic_to_openai_request,
@@ -1004,6 +1005,7 @@ def create_app(
     _semantic = semantic_compressor
     _routing_store = routing_config_store or RoutingConfigStore()
     _routing_config = _routing_store.config()
+    _scene_store = SceneStore()
 
     def _upstream_chat_url(base_url: str) -> str:
         return f"{str(base_url or '').rstrip('/')}/chat/completions"
@@ -1607,6 +1609,71 @@ def create_app(
         _refresh_active_pricing()
         return JSONResponse(payload)
 
+    async def handle_scenes(request: Request) -> JSONResponse:
+        """GET /v1/scenes — list all scenes.  POST /v1/scenes — add/remove/import."""
+        if request.method == "GET":
+            return JSONResponse(_scene_store.export())
+
+        body = await request.json()
+        action = str(body.get("action", "")).strip().lower()
+        try:
+            if action == "add":
+                name = str(body.get("name", "")).strip()
+                primary = str(body.get("primary", "")).strip()
+                if not name or not primary:
+                    return JSONResponse({"error": "name and primary are required"}, status_code=400)
+                fallback_raw = body.get("fallback", [])
+                if isinstance(fallback_raw, str):
+                    fallback = [p.strip() for p in fallback_raw.split(",") if p.strip()]
+                elif isinstance(fallback_raw, list):
+                    fallback = [str(f).strip() for f in fallback_raw if str(f).strip()]
+                else:
+                    fallback = []
+                scene = SceneConfig(
+                    name=name,
+                    primary=primary,
+                    fallback=fallback,
+                    hard_pin=bool(body.get("hard_pin", False)),
+                    description=str(body.get("description", "")),
+                    complexity_override=body.get("complexity_override"),
+                    allowed_providers=body.get("allowed_providers", []),
+                    selection_weights_override=body.get("selection_weights_override"),
+                    max_cost_per_request=body.get("max_cost_per_request"),
+                )
+                stored = _scene_store.add(scene)
+                return JSONResponse({"ok": True, "scene": _serialize_scene_response(stored)})
+            elif action == "remove":
+                name = str(body.get("name", "")).strip()
+                if not name:
+                    return JSONResponse({"error": "name is required"}, status_code=400)
+                removed = _scene_store.remove(name)
+                return JSONResponse({"ok": removed, "name": name})
+            elif action == "import":
+                data = body.get("data", {})
+                count = _scene_store.import_scenes(data)
+                return JSONResponse({"ok": True, "imported": count})
+            else:
+                return JSONResponse(
+                    {"error": "Invalid action", "allowed": ["add", "remove", "import"]},
+                    status_code=400,
+                )
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+
+    async def handle_scene_detail(request: Request) -> JSONResponse:
+        """GET /v1/scenes/<name> — get one scene."""
+        name = request.path_params["name"]
+        scene = _scene_store.get(name)
+        if scene is None:
+            return JSONResponse({"error": f"Scene '{name}' not found"}, status_code=404)
+        return JSONResponse(_serialize_scene_response(scene))
+
+    def _serialize_scene_response(scene: SceneConfig) -> dict:
+        from uncommon_route.scene_store import _serialize_scene
+        data = _serialize_scene(scene)
+        data["model_pool"] = scene.model_pool()
+        return data
+
     async def handle_artifacts(request: Request) -> JSONResponse:
         limit = int(request.query_params.get("limit", "50"))
         return JSONResponse({
@@ -1731,6 +1798,36 @@ def create_app(
         session_id = _resolve_session_id(request, body)
         step_type, tool_names = _classify_step(body)
 
+        # ── Scene resolution ───────────────────────────────────────────
+        # Trigger precedence:
+        #   1. x-uncommon-route-scene header
+        #   2. Virtual model ID: uncommon-route/scene/<name>
+        #   3. (Future: OpenClaw session → scene mapping via plugin)
+        _scene_name: str | None = None
+        _active_scene: SceneConfig | None = None
+
+        # Check header first (highest priority)
+        _scene_header = request.headers.get("x-uncommon-route-scene", "").strip()
+        if _scene_header:
+            _scene_name = _scene_header
+
+        # Check virtual model ID: uncommon-route/scene/<name>
+        if not _scene_name and model.startswith("uncommon-route/scene/"):
+            _scene_name = model[len("uncommon-route/scene/"):].strip()
+            # Treat scene requests as virtual (need routing)
+            if not is_virtual:
+                is_virtual = True
+                routing_mode = RoutingMode.AUTO
+
+        if _scene_name:
+            _active_scene = _scene_store.resolve(_scene_name)
+            if _active_scene:
+                logger.info(
+                    "Scene '%s' active: primary=%s hard_pin=%s",
+                    _active_scene.name, _active_scene.primary, _active_scene.hard_pin,
+                )
+                route_method = f"scene:{_active_scene.name}"
+
         if is_virtual:
             if prompt.startswith("/debug"):
                 debug_prompt = prompt[len("/debug"):].strip() or "hello"
@@ -1741,20 +1838,84 @@ def create_app(
 
             requirements, hints = _extract_requirements(body, step_type)
             user_keyed = _providers.keyed_models() or None
-            decision = route(
-                prompt,
-                system_prompt,
-                max_tokens,
-                config=_routing_config,
-                routing_mode=routing_mode or RoutingMode.AUTO,
-                request_requirements=requirements,
-                workload_hints=hints,
-                user_keyed_models=user_keyed,
-                model_experience=_model_experience,
-                pricing=_get_pricing(),
-                available_models=_mapper.available_models if _mapper.discovered else None,
-                model_capabilities=_routing_config.model_capabilities,
-            )
+
+            # ── Scene-aware routing ──────────────────────────────────
+            if _active_scene and _active_scene.hard_pin:
+                # Hard-pin: bypass classifier AND selector entirely.
+                # Use scene's primary directly; fallback is the ordered chain.
+                from uncommon_route.router.types import (
+                    FallbackOption,
+                    RoutingDecision,
+                    AnswerDepth as _AD,
+                )
+                from uncommon_route.router.structural import estimate_output_budget as _eob
+                _scene_pool = _active_scene.model_pool()
+                _scene_budget = _eob(prompt, "COMPLEX")
+                _scene_cost = _estimate_cost(
+                    _active_scene.primary,
+                    estimate_tokens(prompt),
+                    min(max_tokens, _scene_budget),
+                )
+                _scene_baseline = _estimate_baseline_cost(
+                    estimate_tokens(prompt),
+                    min(max_tokens, _scene_budget),
+                )
+                decision = RoutingDecision(
+                    model=_active_scene.primary,
+                    tier=Tier.COMPLEX,
+                    mode=routing_mode or RoutingMode.AUTO,
+                    confidence=1.0,
+                    method=f"scene:{_active_scene.name}:hard-pin",
+                    reasoning=f"scene={_active_scene.name} hard-pin → {_active_scene.primary}",
+                    cost_estimate=_scene_cost,
+                    baseline_cost=_scene_baseline,
+                    savings=max(0.0, (_scene_baseline - _scene_cost) / _scene_baseline) if _scene_baseline > 0 else 0.0,
+                    complexity=1.0,
+                    fallback_chain=[
+                        FallbackOption(model=m, cost_estimate=0.0, suggested_output_budget=_scene_budget)
+                        for m in _scene_pool[1:]
+                    ],
+                )
+            elif _active_scene:
+                # Soft scene: constrain candidate pool to scene's models,
+                # optionally override complexity, but let select_from_pool
+                # do multi-dimensional scoring (latency/reliability/feedback/bandit).
+                _scene_constraints = _active_scene.as_routing_constraints()
+                _scene_weights = _active_scene.as_selection_weights()
+                decision = route(
+                    prompt,
+                    system_prompt,
+                    max_tokens,
+                    config=_routing_config,
+                    routing_mode=routing_mode or RoutingMode.AUTO,
+                    request_requirements=requirements,
+                    workload_hints=hints,
+                    user_keyed_models=user_keyed,
+                    model_experience=_model_experience,
+                    pricing=_get_pricing(),
+                    available_models=_active_scene.model_pool(),
+                    model_capabilities=_routing_config.model_capabilities,
+                    routing_constraints=_scene_constraints,
+                    tier_floor=_active_scene.tier_floor,
+                    tier_cap=_active_scene.tier_cap,
+                )
+            else:
+                # Normal routing (no scene active)
+                decision = route(
+                    prompt,
+                    system_prompt,
+                    max_tokens,
+                    config=_routing_config,
+                    routing_mode=routing_mode or RoutingMode.AUTO,
+                    request_requirements=requirements,
+                    workload_hints=hints,
+                    user_keyed_models=user_keyed,
+                    model_experience=_model_experience,
+                    pricing=_get_pricing(),
+                    available_models=_mapper.available_models if _mapper.discovered else None,
+                    model_capabilities=_routing_config.model_capabilities,
+                )
+
             selected_model = decision.model
             tier_value = decision.tier.value
             decision_tier = tier_value
@@ -2647,6 +2808,8 @@ def create_app(
         Route("/v1/stats", handle_stats, methods=["GET", "POST"]),
         Route("/v1/selector", handle_selector, methods=["GET", "POST"]),
         Route("/v1/routing-config", handle_routing_config, methods=["GET", "POST"]),
+        Route("/v1/scenes", handle_scenes, methods=["GET", "POST"]),
+        Route("/v1/scenes/{name:str}", handle_scene_detail, methods=["GET"]),
         Route("/v1/artifacts", handle_artifacts, methods=["GET"]),
         Route("/v1/artifacts/{artifact_id:str}", handle_artifact, methods=["GET"]),
         Route("/v1/feedback", handle_feedback, methods=["GET", "POST"]),

--- a/uncommon_route/proxy.py
+++ b/uncommon_route/proxy.py
@@ -78,7 +78,7 @@ from uncommon_route.providers import (
 )
 from uncommon_route.model_map import ModelMapper
 from uncommon_route.routing_config_store import RoutingConfigStore
-from uncommon_route.scene_store import SceneConfig, SceneStore
+from uncommon_route.scene_store import SceneConfig, SceneStore, _serialize_scene
 from uncommon_route.connections_store import ConnectionsStore, mask_api_key, resolve_primary_connection
 from uncommon_route.anthropic_compat import (
     anthropic_to_openai_request,
@@ -1629,16 +1629,29 @@ def create_app(
                     fallback = [str(f).strip() for f in fallback_raw if str(f).strip()]
                 else:
                     fallback = []
+                tier_floor_raw = body.get("tier_floor")
+                tier_floor = Tier(str(tier_floor_raw).upper()) if tier_floor_raw else None
+                tier_cap_raw = body.get("tier_cap")
+                tier_cap = Tier(str(tier_cap_raw).upper()) if tier_cap_raw else None
+                allowed_providers_raw = body.get("allowed_providers", [])
+                allowed_providers = (
+                    [str(p).strip() for p in allowed_providers_raw if str(p).strip()]
+                    if isinstance(allowed_providers_raw, list) else []
+                )
+                max_cost_raw = body.get("max_cost_per_request")
+                max_cost = float(max_cost_raw) if max_cost_raw is not None else None
+                if max_cost is not None and max_cost <= 0:
+                    return JSONResponse({"error": "max_cost_per_request must be positive"}, status_code=400)
                 scene = SceneConfig(
                     name=name,
                     primary=primary,
                     fallback=fallback,
                     hard_pin=bool(body.get("hard_pin", False)),
                     description=str(body.get("description", "")),
-                    complexity_override=body.get("complexity_override"),
-                    allowed_providers=body.get("allowed_providers", []),
-                    selection_weights_override=body.get("selection_weights_override"),
-                    max_cost_per_request=body.get("max_cost_per_request"),
+                    tier_floor=tier_floor,
+                    tier_cap=tier_cap,
+                    allowed_providers=allowed_providers,
+                    max_cost_per_request=max_cost,
                 )
                 stored = _scene_store.add(scene)
                 return JSONResponse({"ok": True, "scene": _serialize_scene_response(stored)})
@@ -1669,7 +1682,6 @@ def create_app(
         return JSONResponse(_serialize_scene_response(scene))
 
     def _serialize_scene_response(scene: SceneConfig) -> dict:
-        from uncommon_route.scene_store import _serialize_scene
         data = _serialize_scene(scene)
         data["model_pool"] = scene.model_pool()
         return data
@@ -1878,10 +1890,9 @@ def create_app(
                 )
             elif _active_scene:
                 # Soft scene: constrain candidate pool to scene's models,
-                # optionally override complexity, but let select_from_pool
-                # do multi-dimensional scoring (latency/reliability/feedback/bandit).
+                # let select_from_pool do multi-dimensional scoring
+                # (latency/reliability/feedback/bandit).
                 _scene_constraints = _active_scene.as_routing_constraints()
-                _scene_weights = _active_scene.as_selection_weights()
                 decision = route(
                     prompt,
                     system_prompt,
@@ -1932,7 +1943,8 @@ def create_app(
             baseline_cost = decision.baseline_cost
             confidence = decision.confidence
             savings = decision.savings
-            route_method = "pool"
+            if not _active_scene:
+                route_method = "pool"
             mode_value = decision.mode.value
 
             body["model"] = selected_model

--- a/uncommon_route/scene_store.py
+++ b/uncommon_route/scene_store.py
@@ -1,0 +1,300 @@
+"""Named scene routing — persistent, user-defined routing profiles.
+
+A *scene* is a named routing preset that overrides (or constrains) the
+normal classifier → selector pipeline.  Scenes let users declare
+domain-specific routing policies like "intimate" (always opus, hard-pin)
+or "construction_crew" (cheap models only, adaptive selection).
+
+Two behaviours depending on ``hard_pin``:
+
+* **hard_pin=True** — bypass classifier *and* selector; use
+  ``primary`` directly with ``fallback`` as the ordered chain.
+* **hard_pin=False** — bypass the classifier (use ``complexity_override``
+  or default 0.5), but let ``select_from_pool`` score within the scene's
+  model list.  This preserves latency/reliability/feedback/bandit scoring.
+
+Trigger precedence (checked in proxy):
+
+1. ``x-uncommon-route-scene: <name>`` request header
+2. Virtual model ID ``uncommon-route/scene/<name>``
+3. OpenClaw session → scene mapping (injected as header by plugin)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from uncommon_route.paths import data_dir
+from uncommon_route.router.types import (
+    RoutingConstraints,
+    SelectionWeights,
+    Tier,
+)
+
+logger = logging.getLogger("uncommon-route.scene")
+
+_DATA_DIR = data_dir()
+_SCENES_FILE = _DATA_DIR / "scenes.json"
+
+
+@dataclass
+class SceneConfig:
+    """A named routing scene."""
+
+    name: str
+    primary: str
+    fallback: list[str] = field(default_factory=list)
+    hard_pin: bool = False
+    description: str = ""
+
+    # When hard_pin=False, this value replaces the classifier output.
+    # None means "run the classifier normally" (scene only constrains
+    # the candidate pool, not the complexity signal).
+    complexity_override: float | None = None
+
+    # Optional tier floor/cap — lets a scene say "at least MEDIUM".
+    tier_floor: Tier | None = None
+    tier_cap: Tier | None = None
+
+    # Provider-level constraint (e.g. only allow anthropic/).
+    allowed_providers: list[str] = field(default_factory=list)
+
+    # Per-scene selection weight overrides (None = use global defaults).
+    selection_weights_override: dict[str, float] | None = None
+
+    # Per-scene spend limit ($/request).  None = no limit.
+    max_cost_per_request: float | None = None
+
+    def model_pool(self) -> list[str]:
+        """Return ordered candidate list: [primary, *fallback]."""
+        seen: set[str] = set()
+        pool: list[str] = []
+        for model in [self.primary, *self.fallback]:
+            normalized = model.strip()
+            if normalized and normalized not in seen:
+                pool.append(normalized)
+                seen.add(normalized)
+        return pool
+
+    def as_routing_constraints(self) -> RoutingConstraints:
+        """Build a RoutingConstraints from scene settings."""
+        return RoutingConstraints(
+            allowed_models=tuple(self.model_pool()),
+            allowed_providers=tuple(self.allowed_providers),
+            max_cost=self.max_cost_per_request,
+        )
+
+    def as_selection_weights(self) -> SelectionWeights | None:
+        """Build SelectionWeights if overrides are defined."""
+        if not self.selection_weights_override:
+            return None
+        defaults = SelectionWeights()
+        kwargs: dict[str, float] = {}
+        for fld in defaults.__dataclass_fields__:
+            kwargs[fld] = self.selection_weights_override.get(
+                fld, getattr(defaults, fld)
+            )
+        return SelectionWeights(**kwargs)
+
+
+def _serialize_scene(scene: SceneConfig) -> dict[str, Any]:
+    """Convert SceneConfig → JSON-safe dict."""
+    data = asdict(scene)
+    # Convert Tier enums to strings
+    if data.get("tier_floor") is not None:
+        data["tier_floor"] = data["tier_floor"].value if isinstance(data["tier_floor"], Tier) else str(data["tier_floor"])
+    else:
+        data.pop("tier_floor", None)
+    if data.get("tier_cap") is not None:
+        data["tier_cap"] = data["tier_cap"].value if isinstance(data["tier_cap"], Tier) else str(data["tier_cap"])
+    else:
+        data.pop("tier_cap", None)
+    # Strip None/empty optionals for cleaner JSON
+    if not data.get("allowed_providers"):
+        data.pop("allowed_providers", None)
+    if data.get("selection_weights_override") is None:
+        data.pop("selection_weights_override", None)
+    if data.get("max_cost_per_request") is None:
+        data.pop("max_cost_per_request", None)
+    if data.get("complexity_override") is None:
+        data.pop("complexity_override", None)
+    return data
+
+
+def _deserialize_scene(data: dict[str, Any]) -> SceneConfig | None:
+    """Parse a JSON dict → SceneConfig.  Returns None on invalid data."""
+    try:
+        name = str(data.get("name", "")).strip().lower()
+        primary = str(data.get("primary", "")).strip()
+        if not name or not primary:
+            return None
+
+        fallback_raw = data.get("fallback", [])
+        fallback = (
+            [str(f).strip() for f in fallback_raw]
+            if isinstance(fallback_raw, list)
+            else [str(fallback_raw).strip()]
+        )
+
+        tier_floor = None
+        if "tier_floor" in data and data["tier_floor"]:
+            try:
+                tier_floor = Tier(str(data["tier_floor"]).upper())
+            except ValueError:
+                pass
+
+        tier_cap = None
+        if "tier_cap" in data and data["tier_cap"]:
+            try:
+                tier_cap = Tier(str(data["tier_cap"]).upper())
+            except ValueError:
+                pass
+
+        allowed_providers = data.get("allowed_providers", [])
+        if not isinstance(allowed_providers, list):
+            allowed_providers = []
+
+        return SceneConfig(
+            name=name,
+            primary=primary,
+            fallback=[f for f in fallback if f],
+            hard_pin=bool(data.get("hard_pin", False)),
+            description=str(data.get("description", "")),
+            complexity_override=data.get("complexity_override"),
+            tier_floor=tier_floor,
+            tier_cap=tier_cap,
+            allowed_providers=[str(p).strip() for p in allowed_providers if str(p).strip()],
+            selection_weights_override=data.get("selection_weights_override"),
+            max_cost_per_request=data.get("max_cost_per_request"),
+        )
+    except Exception:
+        logger.warning("Failed to deserialize scene: %s", data, exc_info=True)
+        return None
+
+
+class SceneStore:
+    """CRUD store for named scenes, backed by a JSON file."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self._path = path or _SCENES_FILE
+        self._scenes: dict[str, SceneConfig] = {}
+        self._load()
+
+    def _load(self) -> None:
+        """Load scenes from disk.  Silently ignores corrupt files."""
+        self._scenes = {}
+        try:
+            if self._path.exists():
+                raw = json.loads(self._path.read_text())
+                if isinstance(raw, dict):
+                    scenes_data = raw.get("scenes", {})
+                    if isinstance(scenes_data, dict):
+                        for _key, scene_data in scenes_data.items():
+                            scene = _deserialize_scene(scene_data)
+                            if scene:
+                                self._scenes[scene.name] = scene
+        except Exception:
+            logger.warning("Failed to load scenes from %s", self._path, exc_info=True)
+
+    def _save(self) -> None:
+        """Persist scenes to disk."""
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            data = {
+                "version": "1.0",
+                "scenes": {
+                    name: _serialize_scene(scene)
+                    for name, scene in sorted(self._scenes.items())
+                },
+            }
+            self._path.write_text(json.dumps(data, indent=2, sort_keys=True))
+            self._path.chmod(0o600)
+        except Exception:
+            logger.error("Failed to save scenes to %s", self._path, exc_info=True)
+
+    def get(self, name: str) -> SceneConfig | None:
+        """Look up a scene by name (case-insensitive)."""
+        return self._scenes.get(name.strip().lower())
+
+    def list(self) -> list[SceneConfig]:
+        """Return all scenes, sorted by name."""
+        return sorted(self._scenes.values(), key=lambda s: s.name)
+
+    def add(self, scene: SceneConfig) -> SceneConfig:
+        """Add or update a scene.  Returns the stored scene."""
+        normalized = SceneConfig(
+            name=scene.name.strip().lower(),
+            primary=scene.primary.strip(),
+            fallback=[f.strip() for f in scene.fallback if f.strip()],
+            hard_pin=scene.hard_pin,
+            description=scene.description,
+            complexity_override=scene.complexity_override,
+            tier_floor=scene.tier_floor,
+            tier_cap=scene.tier_cap,
+            allowed_providers=scene.allowed_providers,
+            selection_weights_override=scene.selection_weights_override,
+            max_cost_per_request=scene.max_cost_per_request,
+        )
+        # Deduplicate fallback against primary
+        normalized = SceneConfig(
+            **{
+                **asdict(normalized),
+                "fallback": [
+                    f for f in normalized.fallback if f != normalized.primary
+                ],
+                "tier_floor": normalized.tier_floor,
+                "tier_cap": normalized.tier_cap,
+            }
+        )
+        self._scenes[normalized.name] = normalized
+        self._save()
+        return normalized
+
+    def remove(self, name: str) -> bool:
+        """Remove a scene.  Returns True if it existed."""
+        key = name.strip().lower()
+        if key in self._scenes:
+            del self._scenes[key]
+            self._save()
+            return True
+        return False
+
+    def resolve(self, name: str) -> SceneConfig | None:
+        """Resolve a scene name, with graceful degradation.
+
+        Returns None if the scene doesn't exist (caller falls back to
+        normal routing).
+        """
+        scene = self.get(name)
+        if scene is None:
+            logger.debug("Scene '%s' not found, falling back to normal routing", name)
+        return scene
+
+    def export(self) -> dict[str, Any]:
+        """Export all scenes as a JSON-serializable dict."""
+        return {
+            "version": "1.0",
+            "scenes": {
+                name: _serialize_scene(scene)
+                for name, scene in sorted(self._scenes.items())
+            },
+        }
+
+    def import_scenes(self, data: dict[str, Any]) -> int:
+        """Import scenes from a dict (merge, not replace).  Returns count added."""
+        count = 0
+        scenes_data = data.get("scenes", {})
+        if isinstance(scenes_data, dict):
+            for _key, scene_data in scenes_data.items():
+                scene = _deserialize_scene(scene_data)
+                if scene:
+                    self._scenes[scene.name] = scene
+                    count += 1
+        if count:
+            self._save()
+        return count

--- a/uncommon_route/scene_store.py
+++ b/uncommon_route/scene_store.py
@@ -9,9 +9,10 @@ Two behaviours depending on ``hard_pin``:
 
 * **hard_pin=True** — bypass classifier *and* selector; use
   ``primary`` directly with ``fallback`` as the ordered chain.
-* **hard_pin=False** — bypass the classifier (use ``complexity_override``
-  or default 0.5), but let ``select_from_pool`` score within the scene's
-  model list.  This preserves latency/reliability/feedback/bandit scoring.
+* **hard_pin=False** — constrain candidate pool to the scene's model
+  list, optionally apply tier_floor/tier_cap, but let the full
+  classifier → selector pipeline score within that pool.
+  This preserves latency/reliability/feedback/bandit scoring.
 
 Trigger precedence (checked in proxy):
 
@@ -25,14 +26,13 @@ from __future__ import annotations
 import json
 import logging
 import os
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
 from uncommon_route.paths import data_dir
 from uncommon_route.router.types import (
     RoutingConstraints,
-    SelectionWeights,
     Tier,
 )
 
@@ -52,20 +52,12 @@ class SceneConfig:
     hard_pin: bool = False
     description: str = ""
 
-    # When hard_pin=False, this value replaces the classifier output.
-    # None means "run the classifier normally" (scene only constrains
-    # the candidate pool, not the complexity signal).
-    complexity_override: float | None = None
-
     # Optional tier floor/cap — lets a scene say "at least MEDIUM".
     tier_floor: Tier | None = None
     tier_cap: Tier | None = None
 
     # Provider-level constraint (e.g. only allow anthropic/).
     allowed_providers: list[str] = field(default_factory=list)
-
-    # Per-scene selection weight overrides (None = use global defaults).
-    selection_weights_override: dict[str, float] | None = None
 
     # Per-scene spend limit ($/request).  None = no limit.
     max_cost_per_request: float | None = None
@@ -89,17 +81,9 @@ class SceneConfig:
             max_cost=self.max_cost_per_request,
         )
 
-    def as_selection_weights(self) -> SelectionWeights | None:
-        """Build SelectionWeights if overrides are defined."""
-        if not self.selection_weights_override:
-            return None
-        defaults = SelectionWeights()
-        kwargs: dict[str, float] = {}
-        for fld in defaults.__dataclass_fields__:
-            kwargs[fld] = self.selection_weights_override.get(
-                fld, getattr(defaults, fld)
-            )
-        return SelectionWeights(**kwargs)
+    def as_selection_weights(self) -> None:
+        """Reserved for future use when route() supports injected weights."""
+        return None
 
 
 def _serialize_scene(scene: SceneConfig) -> dict[str, Any]:
@@ -117,12 +101,8 @@ def _serialize_scene(scene: SceneConfig) -> dict[str, Any]:
     # Strip None/empty optionals for cleaner JSON
     if not data.get("allowed_providers"):
         data.pop("allowed_providers", None)
-    if data.get("selection_weights_override") is None:
-        data.pop("selection_weights_override", None)
     if data.get("max_cost_per_request") is None:
         data.pop("max_cost_per_request", None)
-    if data.get("complexity_override") is None:
-        data.pop("complexity_override", None)
     return data
 
 
@@ -165,11 +145,9 @@ def _deserialize_scene(data: dict[str, Any]) -> SceneConfig | None:
             fallback=[f for f in fallback if f],
             hard_pin=bool(data.get("hard_pin", False)),
             description=str(data.get("description", "")),
-            complexity_override=data.get("complexity_override"),
             tier_floor=tier_floor,
             tier_cap=tier_cap,
             allowed_providers=[str(p).strip() for p in allowed_providers if str(p).strip()],
-            selection_weights_override=data.get("selection_weights_override"),
             max_cost_per_request=data.get("max_cost_per_request"),
         )
     except Exception:
@@ -233,23 +211,15 @@ class SceneStore:
             fallback=[f.strip() for f in scene.fallback if f.strip()],
             hard_pin=scene.hard_pin,
             description=scene.description,
-            complexity_override=scene.complexity_override,
             tier_floor=scene.tier_floor,
             tier_cap=scene.tier_cap,
             allowed_providers=scene.allowed_providers,
-            selection_weights_override=scene.selection_weights_override,
             max_cost_per_request=scene.max_cost_per_request,
         )
         # Deduplicate fallback against primary
-        normalized = SceneConfig(
-            **{
-                **asdict(normalized),
-                "fallback": [
-                    f for f in normalized.fallback if f != normalized.primary
-                ],
-                "tier_floor": normalized.tier_floor,
-                "tier_cap": normalized.tier_cap,
-            }
+        normalized = replace(
+            normalized,
+            fallback=[f for f in normalized.fallback if f != normalized.primary],
         )
         self._scenes[normalized.name] = normalized
         self._save()


### PR DESCRIPTION
Scenes are persistent, user-defined routing profiles that override or constrain the normal classifier → selector pipeline.

Two modes:
- hard_pin: bypass classifier AND selector; use primary model directly
- adaptive: constrain candidate pool to scene models, but preserve multi-dimensional scoring (latency/reliability/feedback/bandit)

Trigger precedence:
1. x-uncommon-route-scene request header
2. Virtual model ID: uncommon-route/scene/<name>
3. (Future) OpenClaw session → scene mapping via plugin

Includes:
- SceneConfig dataclass with full routing options
- SceneStore: CRUD with JSON persistence + import/export
- Proxy integration: scene-aware routing in _handle_chat_core
- REST API: GET/POST /v1/scenes, GET /v1/scenes/<name>
- CLI: uncommon-route scene list|add|remove|show
- 21 unit tests (all passing, 302 total suite green)