### PR TITLE
fix: handle reasoning_content in streaming SSE responses

### DIFF
--- a/uncommon_route/anthropic_compat.py
+++ b/uncommon_route/anthropic_compat.py
@@ -802,8 +802,11 @@ class OpenAIToAnthropicStreamConverter:
         delta = choices[0].get("delta", {})
         finish_reason = choices[0].get("finish_reason")
 
-        # Text content
+        # Text content (fall back to reasoning_content for models that
+        # return thinking/reasoning in a separate field with content=null)
         content = delta.get("content")
+        if (content is None or content == "") and delta.get("reasoning_content"):
+            content = delta["reasoning_content"]
         if content is not None and content != "":
             if self._block_type != "text":
                 if self._block_type is not None:

--- a/uncommon_route/cache_support.py
+++ b/uncommon_route/cache_support.py
@@ -321,6 +321,12 @@ def parse_stream_usage_metrics(
 
     anthropic_usage: dict[str, Any] = {}
     latest: UsageMetrics | None = None
+    # Fallback counters: count output tokens from stream deltas when the
+    # upstream does not include a usage summary (common for minimax/moonshot
+    # routed through Commonstack).
+    fallback_output_tokens = 0
+    fallback_prompt_tokens = 0
+    has_any_content = False
 
     for line in text.splitlines():
         if not line.startswith("data:"):
@@ -353,6 +359,48 @@ def parse_stream_usage_metrics(
             )
             if parsed is not None:
                 latest = parsed
+
+        # Count content/reasoning_content tokens as fallback when usage is missing
+        choices = data.get("choices")
+        if isinstance(choices, list) and choices:
+            delta = choices[0].get("delta") if isinstance(choices[0], dict) else None
+            if isinstance(delta, dict):
+                content = delta.get("content") or delta.get("reasoning_content") or ""
+                if content:
+                    has_any_content = True
+                    # Rough approximation: ~4 chars per token for mixed-language text
+                    fallback_output_tokens += max(1, len(content) // 4)
+            # Some providers include prompt_tokens in the first chunk's usage
+            chunk_usage = data.get("usage")
+            if isinstance(chunk_usage, dict) and chunk_usage.get("prompt_tokens"):
+                fallback_prompt_tokens = max(fallback_prompt_tokens, int(chunk_usage["prompt_tokens"]))
+
+    # If we got content but no usage summary, build a rough estimate so that
+    # stats/cost tracking records *something* instead of null/zero.
+    if latest is None and has_any_content and fallback_output_tokens > 0:
+        mp = pricing.get(model)
+        actual_cost: float | None = None
+        if mp is not None:
+            actual_cost = estimate_usage_cost(
+                input_tokens_uncached=fallback_prompt_tokens,
+                output_tokens=fallback_output_tokens,
+                cache_read_input_tokens=0,
+                cache_write_input_tokens=0,
+                pricing=mp,
+            )
+        latest = UsageMetrics(
+            input_tokens_total=fallback_prompt_tokens,
+            input_tokens_uncached=fallback_prompt_tokens,
+            output_tokens=fallback_output_tokens,
+            cache_read_input_tokens=0,
+            cache_write_input_tokens=0,
+            total_tokens=fallback_prompt_tokens + fallback_output_tokens,
+            ttft_ms=None,
+            tps=None,
+            actual_cost=actual_cost,
+            input_cost_multiplier=1.0,
+            cache_hit_ratio=0.0,
+        )
     return latest
 
 

--- a/uncommon_route/proxy.py
+++ b/uncommon_route/proxy.py
@@ -859,6 +859,48 @@ def _extract_requirements(body: dict, step_type: str, prompt: str = "") -> tuple
     return features.request_requirements(), features.workload_hints()
 
 
+def _normalize_reasoning_content_chunk(raw: bytes) -> bytes:
+    """Rewrite SSE chunks: move reasoning_content into content when content is null.
+
+    Some upstream models (e.g. GLM, minimax) return all text in
+    ``delta.reasoning_content`` with ``delta.content: null``.  Clients that
+    only read ``content`` (like OpenClaw) see an empty response.  This helper
+    patches the SSE data lines in-place so downstream consumers always find
+    the text in ``content``.
+    """
+    try:
+        text = raw.decode("utf-8")
+    except Exception:
+        return raw
+    lines = text.split("\n")
+    changed = False
+    for i, line in enumerate(lines):
+        if not line.startswith("data:"):
+            continue
+        payload = line[5:].strip()
+        if not payload or payload == "[DONE]":
+            continue
+        try:
+            data = json.loads(payload)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        choices = data.get("choices")
+        if not isinstance(choices, list) or not choices:
+            continue
+        delta = choices[0].get("delta")
+        if not isinstance(delta, dict):
+            continue
+        rc = delta.get("reasoning_content")
+        if rc is not None and (delta.get("content") is None or delta.get("content") == ""):
+            delta["content"] = rc
+            del delta["reasoning_content"]
+            lines[i] = f"data: {json.dumps(data, ensure_ascii=False)}"
+            changed = True
+    if not changed:
+        return raw
+    return "\n".join(lines).encode("utf-8")
+
+
 _MODEL_ERROR_PATTERNS = ("model", "not found", "not available", "does not exist", "unsupported", "invalid model")
 
 
@@ -2824,7 +2866,7 @@ def create_app(
                     try:
                         async for chunk in stream_resp.aiter_bytes():
                             stream_chunks.append(chunk)
-                            yield chunk
+                            yield _normalize_reasoning_content_chunk(chunk)
                         _record_stream_success(
                             parse_stream_usage_metrics(stream_chunks, selected_model, _get_pricing())
                         )


### PR DESCRIPTION
## Summary

  Some upstream models (e.g. GLM, minimax, moonshot) routed through Commonstack return text in
  `delta.reasoning_content` with `delta.content` set to `null`. This is a de facto standard
  introduced by DeepSeek-R1 and widely adopted by Chinese LLM providers. Clients that only read
  the `content` field (like OpenClaw) see empty responses.

  - **proxy.py**: Add `_normalize_reasoning_content_chunk()` to rewrite SSE chunks in
    `sse_passthrough`, moving `reasoning_content` into `content`
  - **anthropic_compat.py**: Fall back to `reasoning_content` in
    `OpenAIToAnthropicStreamConverter._on_chunk()` when `content` is null
  - **cache_support.py**: Add fallback token counting in `parse_stream_usage_metrics()`
    when upstream returns no usage summary, estimating output tokens from delta content
    to avoid null/zero stats

  ## Reproduction

  1. Configure upstream to Commonstack gateway
  2. Send a streaming request that routes to a reasoning model (e.g. `zai-org/glm-4.6`,
     `minimax/minimax-m2`)
  3. Observe SSE chunks: `{"delta": {"content": null, "reasoning_content": "..."}}`
  4. Client receives empty response