### PR TITLE
fix: clamp negative costs before log1p to prevent ValueError

### DIFF
--- a/uncommon_route/router/selector.py
+++ b/uncommon_route/router/selector.py
@@ -751,7 +751,7 @@ def select_from_pool(
         for m in candidates
     }
     cheapest_cost = min(dollar_costs.values()) if dollar_costs else 0.0
-    log_dollar_costs = {m: math.log1p(c * 1000)
+    log_dollar_costs = {m: math.log1p(max(c * 1000, 0))
                         for m, c in dollar_costs.items()}
     max_log_dc = max(log_dollar_costs.values()) if log_dollar_costs else 1.0
     min_log_dc = min(log_dollar_costs.values()) if log_dollar_costs else 0.0


### PR DESCRIPTION
## Summary

- Fixes a `ValueError` crash in `select_from_pool` when upstream providers (e.g. OpenRouter) return models with negative or zero pricing
- `math.log1p(c * 1000)` requires its argument to be > -1; negative costs like -102.0 produce `c * 1000 = -102000.0`, which crashes
- Fix: clamp the `log1p` argument to a minimum of 0 with `max(c * 1000, 0)`, so negative-cost models are treated as free (`log1p(0) = 0`)

## Details

The one-line change is in `uncommon_route/router/selector.py` line 754. For positive costs, `max(c * 1000, 0)` is a no-op, so existing behavior is completely unchanged. For negative costs, the model gets the lowest possible log-cost score (0), which correctly ranks it as the cheapest option.

## Test plan

- [x] Verified that `math.log1p(max(-102000.0, 0))` returns `0.0` (no crash)
- [x] Verified that `math.log1p(max(5.0, 0))` returns the same as `math.log1p(5.0)` (no behavior change for positive costs)
- [x] Integration test with OpenRouter models that report negative pricing

🤖 Generated with [Claude Code](https://claude.com/claude-code)