### PR TITLE
fix: sanitize tool_use.id to match Anthropic's pattern

### DIFF
--- a/tests/test_anthropic_compat.py
+++ b/tests/test_anthropic_compat.py
@@ -10,6 +10,7 @@ import pytest
 from starlette.testclient import TestClient
 
 from uncommon_route.anthropic_compat import (
+    _sanitize_tool_id,
     anthropic_to_openai_response,
     anthropic_to_openai_request,
     AnthropicToOpenAIStreamConverter,
@@ -607,6 +608,74 @@ class TestAnthropicToOpenAIStreamConverter:
         usage_chunk = next(event for event in parsed if event.get("choices") == [])
         assert usage_chunk["usage"]["prompt_tokens"] == 141
         assert usage_chunk["usage"]["completion_tokens"] == 7
+
+
+# =========================================================================
+# Tool ID sanitization (issue #12)
+# =========================================================================
+
+class TestToolIdSanitization:
+    def test_valid_id_unchanged(self) -> None:
+        assert _sanitize_tool_id("toolu_01ABC123") == "toolu_01ABC123"
+        assert _sanitize_tool_id("call_abc-XYZ_99") == "call_abc-XYZ_99"
+
+    def test_dots_replaced(self) -> None:
+        assert _sanitize_tool_id("call_abc.def.123") == "call_abc_def_123"
+
+    def test_colons_replaced(self) -> None:
+        assert _sanitize_tool_id("tool:use:id") == "tool_use_id"
+
+    def test_empty_generates_toolu_prefix(self) -> None:
+        result = _sanitize_tool_id("")
+        assert result.startswith("toolu_")
+        assert len(result) > 6
+
+    def test_deterministic(self) -> None:
+        assert _sanitize_tool_id("a.b:c") == _sanitize_tool_id("a.b:c")
+
+    def test_roundtrip_openai_response_sanitizes(self) -> None:
+        openai_resp = {
+            "choices": [{"message": {
+                "role": "assistant",
+                "content": "ok",
+                "tool_calls": [{"id": "call_abc.def:123", "type": "function",
+                                "function": {"name": "read", "arguments": "{}"}}],
+            }, "finish_reason": "tool_calls"}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        }
+        anthropic_resp = openai_to_anthropic_response(openai_resp, "test-model")
+        tool_block = next(b for b in anthropic_resp["content"] if b["type"] == "tool_use")
+        assert tool_block["id"] == "call_abc_def_123"
+
+    def test_roundtrip_openai_request_sanitizes(self) -> None:
+        openai_req = {
+            "model": "test",
+            "max_tokens": 100,
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": None,
+                 "tool_calls": [{"id": "call_x.y:z", "type": "function",
+                                 "function": {"name": "bash", "arguments": "{}"}}]},
+                {"role": "tool", "tool_call_id": "call_x.y:z", "content": "done"},
+            ],
+        }
+        anthropic_req = openai_to_anthropic_request(openai_req)
+        assistant_msg = anthropic_req["messages"][1]
+        tool_use = next(b for b in assistant_msg["content"] if b["type"] == "tool_use")
+        assert tool_use["id"] == "call_x_y_z"
+
+    def test_streaming_converter_sanitizes(self) -> None:
+        converter = OpenAIToAnthropicStreamConverter("test-model")
+        chunk = json.dumps({
+            "choices": [{"delta": {"tool_calls": [
+                {"id": "call_a.b:c", "type": "function",
+                 "function": {"name": "read", "arguments": ""}}
+            ]}, "finish_reason": None}],
+        }).encode()
+        events = converter.feed(b"data: " + chunk + b"\n\n")
+        event_data = [json.loads(e.split(b"\n")[1].removeprefix(b"data: ")) for e in events if b"content_block_start" in e]
+        assert len(event_data) == 1
+        assert event_data[0]["content_block"]["id"] == "call_a_b_c"
 
 
 # =========================================================================

--- a/uncommon_route/anthropic_compat.py
+++ b/uncommon_route/anthropic_compat.py
@@ -14,9 +14,21 @@ Key differences handled:
 from __future__ import annotations
 
 import json
+import re
 import time
 import uuid
 from typing import Any
+
+_VALID_TOOL_ID_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+def _sanitize_tool_id(tid: str) -> str:
+    """Ensure a tool ID conforms to Anthropic's ``^[a-zA-Z0-9_-]+$`` pattern."""
+    if tid and _VALID_TOOL_ID_RE.match(tid):
+        return tid
+    if not tid:
+        return f"toolu_{uuid.uuid4().hex[:24]}"
+    return re.sub(r"[^a-zA-Z0-9_-]", "_", tid)
 
 
 # ---------------------------------------------------------------------------
@@ -178,7 +190,7 @@ def openai_to_anthropic_request(body: dict[str, Any]) -> dict[str, Any]:
                     input_data = {}
                 blocks.append({
                     "type": "tool_use",
-                    "id": tc.get("id", ""),
+                    "id": _sanitize_tool_id(tc.get("id", "")),
                     "name": fn.get("name", ""),
                     "input": input_data,
                 })
@@ -454,7 +466,7 @@ def openai_to_anthropic_response(
             input_data = {}
         content_blocks.append({
             "type": "tool_use",
-            "id": tc.get("id", ""),
+            "id": _sanitize_tool_id(tc.get("id", "")),
             "name": fn.get("name", ""),
             "input": input_data,
         })
@@ -821,7 +833,7 @@ class OpenAIToAnthropicStreamConverter:
             if tc_id:
                 if self._block_type is not None:
                     events.append(self._stop_block())
-                events.append(self._start_block("tool_use", id=tc_id, name=tc_name or ""))
+                events.append(self._start_block("tool_use", id=_sanitize_tool_id(tc_id or ""), name=tc_name or ""))
 
             if tc_args:
                 events.append(self._block_delta({


### PR DESCRIPTION
## What

Sanitize tool_use IDs during OpenAI ↔ Anthropic format conversion to prevent 400 errors when IDs contain characters outside Anthropic's `^[a-zA-Z0-9_-]+$` pattern.

## Why

When UncommonRoute routes a request to an OpenAI-compatible upstream, the upstream may return tool call IDs containing dots (`.`), colons (`:`), or other characters that are valid in OpenAI's format but violate Anthropic's stricter pattern. If these IDs are round-tripped through Claude Code and the next request gets routed to a real Anthropic backend, Anthropic rejects the request with 400.

This is a silent, intermittent failure that only manifests when routing switches between providers mid-conversation — exactly the scenario UncommonRoute enables.

## What's included

**`uncommon_route/anthropic_compat.py`**
- `_sanitize_tool_id()`: deterministic replacement of invalid characters with `_`. Valid IDs pass through unchanged (regex pre-check, zero overhead). Empty IDs get a generated `toolu_` prefix.
- Applied at 3 conversion points covering the full pipeline:
  1. `openai_to_anthropic_response` (non-streaming)
  2. `openai_to_anthropic_request` (history/context conversion)
  3. `OpenAIToAnthropicStreamConverter` (streaming)

**`tests/test_anthropic_compat.py`**
- 8 new tests: valid passthrough, dot replacement, colon replacement, empty ID generation, deterministic behavior, response roundtrip, request roundtrip, streaming roundtrip

## Testing

```
$ pytest tests/test_anthropic_compat.py::TestToolIdSanitization -v
8 passed in 0.02s
```

All 45 pre-existing tests continue to pass. 5 pre-existing integration tests fail (upstream unreachable / auth priority) — these failures are unrelated to this change and reproduce on a clean checkout.

Fixes #12

---

## Additional fix: streaming tool_call without id (#18)

The same PR also fixes a crash in `OpenAIToAnthropicStreamConverter` when an upstream provider sends a streaming tool_call delta without an `id` field. Without the guard, `input_json_delta` events are emitted before a `tool_use` block is opened, causing:

```
API Error: Content block is not a input_json block
```

The fix checks `self._block_type` before emitting `input_json_delta` and auto-opens a `tool_use` block if needed (3 lines added in the streaming converter).

Fixes #18
