### PR TITLE
Settle open PR fixes and Docker support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,36 @@
+FROM python:3.12-slim
+
+ARG UNCOMMON_ROUTE_INSTALL_EXTRAS=""
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    UNCOMMON_ROUTE_HOST=0.0.0.0 \
+    UNCOMMON_ROUTE_PORT=8403 \
+    UNCOMMON_ROUTE_DATA_DIR=/data
+
+WORKDIR /app
+
+RUN groupadd --system uncommon-route \
+    && useradd --system --create-home --gid uncommon-route uncommon-route
+
+COPY . /app
+COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+RUN python -m pip install --upgrade pip \
+    && if [ -n "${UNCOMMON_ROUTE_INSTALL_EXTRAS}" ]; then \
+         python -m pip install ".[${UNCOMMON_ROUTE_INSTALL_EXTRAS}]"; \
+       else \
+         python -m pip install .; \
+       fi \
+    && chmod +x /usr/local/bin/docker-entrypoint.sh \
+    && mkdir -p /data \
+    && chown -R uncommon-route:uncommon-route /app /data
+
+USER uncommon-route
+
+EXPOSE 8403
+VOLUME ["/data"]
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD []

--- a/docker/Dockerfile.dockerignore
+++ b/docker/Dockerfile.dockerignore
@@ -1,0 +1,14 @@
+.git
+.venv
+__pycache__
+*.pyc
+.pytest_cache
+.mypy_cache
+.ruff_cache
+dist
+build
+node_modules
+frontend/dashboard/node_modules
+frontend/dashboard/dist
+*.egg-info
+.DS_Store

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,28 @@
+# Docker
+
+Build a local image from the repository root:
+
+```bash
+docker build -f docker/Dockerfile -t uncommon-route .
+```
+
+Run the proxy with a configured upstream:
+
+```bash
+docker run --rm -p 8403:8403 \
+  -e UNCOMMON_ROUTE_UPSTREAM=https://api.commonstack.ai/v1 \
+  -e UNCOMMON_ROUTE_API_KEY=... \
+  -v uncommon-route-data:/data \
+  uncommon-route
+```
+
+Optional extras can be installed at build time:
+
+```bash
+docker build -f docker/Dockerfile \
+  --build-arg UNCOMMON_ROUTE_INSTALL_EXTRAS=v2 \
+  -t uncommon-route:v2 .
+```
+
+The container stores runtime state under `/data`, mapped from
+`UNCOMMON_ROUTE_DATA_DIR`.

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -gt 0 ]; then
+  exec "$@"
+fi
+
+set -- uncommon-route serve \
+  --host "${UNCOMMON_ROUTE_HOST:-0.0.0.0}" \
+  --port "${UNCOMMON_ROUTE_PORT:-8403}"
+
+if [ -n "${UNCOMMON_ROUTE_UPSTREAM:-}" ]; then
+  set -- "$@" --upstream "${UNCOMMON_ROUTE_UPSTREAM}"
+fi
+
+if [ -n "${UNCOMMON_ROUTE_COMPOSITION_CONFIG:-}" ]; then
+  set -- "$@" --composition-config "${UNCOMMON_ROUTE_COMPOSITION_CONFIG}"
+fi
+
+exec "$@"

--- a/frontend/dashboard/vite.config.ts
+++ b/frontend/dashboard/vite.config.ts
@@ -4,6 +4,12 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
   base: "/dashboard/",
+  server: {
+    proxy: {
+      "/health": "http://localhost:8403",
+      "/v1": "http://localhost:8403",
+    },
+  },
   build: {
     outDir: "../../uncommon_route/static",
     emptyOutDir: true,

--- a/tests/test_anthropic_compat.py
+++ b/tests/test_anthropic_compat.py
@@ -374,6 +374,32 @@ class TestOpenAIToAnthropicRequest:
         assert any(block["type"] == "tool_use" for block in out["messages"][1]["content"])
         assert out["messages"][2]["content"][0]["type"] == "tool_result"
 
+    def test_openai_request_sanitizes_invalid_tool_ids_consistently(self) -> None:
+        body = {
+            "model": "claude-sonnet",
+            "max_tokens": 1024,
+            "messages": [
+                {"role": "user", "content": "Use the tool"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [{
+                        "id": "call.with:bad/chars",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    }],
+                },
+                {"role": "tool", "tool_call_id": "call.with:bad/chars", "content": "done"},
+            ],
+        }
+
+        out = openai_to_anthropic_request(body)
+
+        tool_use = next(block for block in out["messages"][1]["content"] if block["type"] == "tool_use")
+        tool_result = out["messages"][2]["content"][0]
+        assert tool_use["id"] == "call_with_bad_chars"
+        assert tool_result["tool_use_id"] == "call_with_bad_chars"
+
     def test_openai_request_preserves_thinking_blocks(self) -> None:
         body = {
             "model": "claude-sonnet",
@@ -433,6 +459,40 @@ class TestOpenAIToAnthropicRequest:
         assert block["id"] == "call_abc"
         assert block["name"] == "get_weather"
         assert block["input"] == {"city": "NYC"}
+
+    def test_tool_calls_response_sanitizes_invalid_tool_id(self) -> None:
+        oai = {
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [{
+                        "id": "call.with:bad/chars",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    }],
+                },
+                "finish_reason": "tool_calls",
+            }],
+            "usage": {},
+        }
+        out = openai_to_anthropic_response(oai, "model-x")
+        assert out["content"][0]["id"] == "call_with_bad_chars"
+
+    def test_response_uses_reasoning_content_when_content_is_empty(self) -> None:
+        oai = {
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "reasoning_content": "visible reasoning answer",
+                },
+                "finish_reason": "stop",
+            }],
+            "usage": {},
+        }
+        out = openai_to_anthropic_response(oai, "model-x")
+        assert out["content"] == [{"type": "text", "text": "visible reasoning answer"}]
 
     def test_mixed_text_and_tools(self) -> None:
         oai = {
@@ -617,6 +677,39 @@ class TestStreamConverter:
 
         msg_delta = next(e for e in parsed if e["_event"] == "message_delta")
         assert msg_delta["delta"]["stop_reason"] == "tool_use"
+
+    def test_reasoning_content_stream_emits_text_delta(self) -> None:
+        converter = OpenAIToAnthropicStreamConverter(model="m")
+
+        events = converter.feed(_make_oai_sse({
+            "choices": [{
+                "delta": {"content": None, "reasoning_content": "reasoned answer"},
+                "finish_reason": "stop",
+            }],
+        }))
+        events.extend(converter.finish())
+        parsed = _parse_anthropic_events(events)
+        deltas = [e for e in parsed if e["_event"] == "content_block_delta"]
+        assert deltas[0]["delta"] == {"type": "text_delta", "text": "reasoned answer"}
+
+    def test_tool_call_stream_sanitizes_invalid_initial_id(self) -> None:
+        converter = OpenAIToAnthropicStreamConverter(model="m")
+
+        events = converter.feed(_make_oai_sse({
+            "choices": [{
+                "delta": {"tool_calls": [{
+                    "index": 0,
+                    "id": "call.with:bad/chars",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }]},
+                "finish_reason": "tool_calls",
+            }],
+        }))
+        events.extend(converter.finish())
+        parsed = _parse_anthropic_events(events)
+        block_start = next(e for e in parsed if e["_event"] == "content_block_start")
+        assert block_start["content_block"]["id"] == "call_with_bad_chars"
 
     def test_tool_call_stream_without_initial_id_starts_valid_tool_block(self) -> None:
         converter = OpenAIToAnthropicStreamConverter(model="m")

--- a/tests/test_cache_support.py
+++ b/tests/test_cache_support.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from uncommon_route.cache_support import apply_anthropic_cache_breakpoints
+import json
+
+from uncommon_route.cache_support import apply_anthropic_cache_breakpoints, parse_stream_usage_metrics
+from uncommon_route.router.types import ModelPricing
 
 
 def test_anthropic_cache_breakpoints_do_not_upgrade_after_existing_5m() -> None:
@@ -58,3 +61,30 @@ def test_anthropic_cache_breakpoints_still_use_1h_when_safe() -> None:
     assert plan.anthropic_ttl == "1h"
     assert body["tools"][-1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
     assert body["system"][-1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+
+def test_stream_usage_falls_back_to_reasoning_content_tokens_when_usage_missing() -> None:
+    chunk = (
+        "data: "
+        + json.dumps({
+            "choices": [{
+                "delta": {
+                    "content": None,
+                    "reasoning_content": "reasoned answer text",
+                },
+                "finish_reason": None,
+            }],
+        })
+        + "\n\n"
+    ).encode()
+
+    usage = parse_stream_usage_metrics(
+        [chunk],
+        "test/model",
+        {"test/model": ModelPricing(1.0, 2.0)},
+    )
+
+    assert usage is not None
+    assert usage.output_tokens > 0
+    assert usage.total_tokens == usage.output_tokens
+    assert usage.actual_cost is not None

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -14,7 +14,12 @@ from uncommon_route.artifacts import ArtifactStore
 from uncommon_route.composition import CompositionPolicy
 from uncommon_route.connections_store import ConnectionsStore, InMemoryConnectionsStorage
 from uncommon_route.model_experience import InMemoryModelExperienceStorage, ModelExperienceStore
-from uncommon_route.proxy import _extract_current_message, _extract_prompt, create_app
+from uncommon_route.proxy import (
+    _extract_current_message,
+    _extract_prompt,
+    _normalize_reasoning_content_chunk,
+    create_app,
+)
 from uncommon_route.router.config import routing_mode_from_model
 from uncommon_route.routing_config_store import InMemoryRoutingConfigStorage, RoutingConfigStore
 from uncommon_route.semantic import SemanticCallResult, SideChannelConfig, SideChannelTaskConfig
@@ -440,6 +445,45 @@ class TestPromptExtraction:
             ],
         })
         assert prompt == "summarize this file"
+
+
+def test_reasoning_content_chunk_is_mirrored_into_content() -> None:
+    raw = (
+        "data: "
+        + json.dumps({
+            "choices": [{
+                "delta": {
+                    "content": None,
+                    "reasoning_content": "reasoned answer",
+                },
+                "finish_reason": None,
+            }],
+        })
+        + "\n\n"
+    ).encode()
+
+    out = _normalize_reasoning_content_chunk(raw)
+    payload = json.loads(out.decode().split("data: ", 1)[1])
+    delta = payload["choices"][0]["delta"]
+    assert delta["content"] == "reasoned answer"
+    assert delta["reasoning_content"] == "reasoned answer"
+
+
+def test_recursion_guard_blocks_virtual_model_before_upstream_call() -> None:
+    app = create_app(upstream="http://127.0.0.1:1/fake")
+    client = TestClient(app, raise_server_exceptions=False)
+
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "uncommon-route/auto",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+        headers={"x-uncommon-route-recursion-guard": "1"},
+    )
+
+    assert resp.status_code == 400
+    assert "cannot be routed recursively" in resp.json()["error"]["message"]
 
 
 @pytest.fixture

--- a/tests/test_usage_modes.py
+++ b/tests/test_usage_modes.py
@@ -199,6 +199,8 @@ class TestCLI:
             "ANTHROPIC_BASE_URL": "http://localhost:8403",
             "http_proxy": "http://127.0.0.1:9",
             "https_proxy": "http://127.0.0.1:9",
+            "NO_PROXY": "",
+            "no_proxy": "",
         }
 
         r = run_cli(["doctor"], env=env)

--- a/uncommon_route/anthropic_compat.py
+++ b/uncommon_route/anthropic_compat.py
@@ -14,7 +14,9 @@ Key differences handled:
 from __future__ import annotations
 
 from copy import deepcopy
+import hashlib
 import json
+import re
 import time
 import uuid
 from typing import Any
@@ -50,6 +52,35 @@ _STATUS_TO_ERROR_TYPE: dict[int, str] = {
 }
 
 _PASSTHROUGH_CONTENT_BLOCK_TYPES = {"thinking", "redacted_thinking"}
+_ANTHROPIC_TOOL_ID_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+def _sanitize_anthropic_tool_id(
+    tool_id: object,
+    *,
+    existing: set[str] | None = None,
+) -> str:
+    """Return a valid Anthropic tool id, preserving valid ids verbatim."""
+    raw = str(tool_id or "")
+    if raw and _ANTHROPIC_TOOL_ID_RE.fullmatch(raw):
+        candidate = raw
+    elif raw:
+        candidate = re.sub(r"[^a-zA-Z0-9_-]", "_", raw)
+        if not candidate:
+            candidate = "toolu"
+    else:
+        candidate = f"toolu_{uuid.uuid4().hex[:24]}"
+
+    if existing is None or candidate not in existing:
+        return candidate
+
+    suffix = hashlib.sha1(raw.encode("utf-8")).hexdigest()[:8] if raw else uuid.uuid4().hex[:8]
+    candidate_with_suffix = f"{candidate}_{suffix}"
+    counter = 2
+    while candidate_with_suffix in existing:
+        candidate_with_suffix = f"{candidate}_{suffix}_{counter}"
+        counter += 1
+    return candidate_with_suffix
 
 
 # ---------------------------------------------------------------------------
@@ -172,6 +203,8 @@ def openai_to_anthropic_request(body: dict[str, Any]) -> dict[str, Any]:
 
     system_blocks: list[dict[str, Any]] = []
     messages: list[dict[str, Any]] = []
+    tool_id_map: dict[str, str] = {}
+    used_tool_ids: set[str] = set()
 
     for msg in body.get("messages", []):
         if not isinstance(msg, dict):
@@ -194,13 +227,18 @@ def openai_to_anthropic_request(body: dict[str, Any]) -> dict[str, Any]:
             blocks = _openai_content_to_anthropic_blocks(content)
             for tc in msg.get("tool_calls", []) or []:
                 fn = tc.get("function", {}) if isinstance(tc, dict) else {}
+                raw_tool_id = tc.get("id", "") if isinstance(tc, dict) else ""
+                safe_tool_id = _sanitize_anthropic_tool_id(raw_tool_id, existing=used_tool_ids)
+                used_tool_ids.add(safe_tool_id)
+                if raw_tool_id:
+                    tool_id_map[str(raw_tool_id)] = safe_tool_id
                 try:
                     input_data = json.loads(fn.get("arguments", "{}"))
                 except json.JSONDecodeError:
                     input_data = {}
                 blocks.append({
                     "type": "tool_use",
-                    "id": tc.get("id", ""),
+                    "id": safe_tool_id,
                     "name": fn.get("name", ""),
                     "input": input_data,
                 })
@@ -211,11 +249,16 @@ def openai_to_anthropic_request(body: dict[str, Any]) -> dict[str, Any]:
             tool_result = content
             if isinstance(tool_result, list):
                 tool_result = _flatten_content_blocks(tool_result)
+            raw_tool_call_id = str(msg.get("tool_call_id", "") or "")
+            safe_tool_call_id = (
+                tool_id_map.get(raw_tool_call_id)
+                or _sanitize_anthropic_tool_id(raw_tool_call_id)
+            )
             messages.append({
                 "role": "user",
                 "content": [{
                     "type": "tool_result",
-                    "tool_use_id": msg.get("tool_call_id", ""),
+                    "tool_use_id": safe_tool_call_id,
                     "content": str(tool_result or ""),
                 }],
             })
@@ -479,6 +522,8 @@ def openai_to_anthropic_response(
     content_blocks: list[dict[str, Any]] = []
 
     text = message.get("content")
+    if (text is None or text == "") and message.get("reasoning_content"):
+        text = message.get("reasoning_content")
     if text:
         content_blocks.append({"type": "text", "text": text})
 
@@ -490,7 +535,7 @@ def openai_to_anthropic_response(
             input_data = {}
         content_blocks.append({
             "type": "tool_use",
-            "id": tc.get("id", ""),
+            "id": _sanitize_anthropic_tool_id(tc.get("id", "")),
             "name": fn.get("name", ""),
             "input": input_data,
         })
@@ -844,8 +889,11 @@ class OpenAIToAnthropicStreamConverter:
         delta = choices[0].get("delta", {})
         finish_reason = choices[0].get("finish_reason")
 
-        # Text content
+        # Text content. Some OpenAI-compatible reasoning models stream their
+        # visible text in reasoning_content while leaving content null.
         content = delta.get("content")
+        if (content is None or content == "") and delta.get("reasoning_content"):
+            content = delta.get("reasoning_content")
         if content is not None and content != "":
             if self._block_type != "text":
                 if self._block_type is not None:
@@ -868,7 +916,7 @@ class OpenAIToAnthropicStreamConverter:
             tc_args = tc_fn.get("arguments", "")
 
             if tc_id:
-                meta["id"] = tc_id
+                meta["id"] = _sanitize_anthropic_tool_id(tc_id)
             if tc_name:
                 meta["name"] = tc_name
 

--- a/uncommon_route/cache_support.py
+++ b/uncommon_route/cache_support.py
@@ -327,6 +327,9 @@ def parse_stream_usage_metrics(
 
     anthropic_usage: dict[str, Any] = {}
     latest: UsageMetrics | None = None
+    fallback_output_tokens = 0
+    fallback_prompt_tokens = 0
+    fallback_has_content = False
 
     for line in text.splitlines():
         if not line.startswith("data:"):
@@ -359,6 +362,45 @@ def parse_stream_usage_metrics(
             )
             if parsed is not None:
                 latest = parsed
+        choices = data.get("choices")
+        if isinstance(choices, list) and choices:
+            first_choice = choices[0]
+            delta = first_choice.get("delta") if isinstance(first_choice, dict) else None
+            if isinstance(delta, dict):
+                content = delta.get("content") or delta.get("reasoning_content") or ""
+                if isinstance(content, str) and content:
+                    fallback_has_content = True
+                    fallback_output_tokens += max(1, len(content) // 4)
+            usage = data.get("usage")
+            if isinstance(usage, dict) and usage.get("prompt_tokens"):
+                try:
+                    fallback_prompt_tokens = max(fallback_prompt_tokens, int(usage["prompt_tokens"]))
+                except (TypeError, ValueError):
+                    pass
+    if latest is None and fallback_has_content and fallback_output_tokens > 0:
+        mp = pricing.get(model)
+        actual_cost = None
+        if mp is not None:
+            actual_cost = estimate_usage_cost(
+                input_tokens_uncached=fallback_prompt_tokens,
+                output_tokens=fallback_output_tokens,
+                cache_read_input_tokens=0,
+                cache_write_input_tokens=0,
+                pricing=mp,
+            )
+        latest = UsageMetrics(
+            input_tokens_total=fallback_prompt_tokens,
+            input_tokens_uncached=fallback_prompt_tokens,
+            output_tokens=fallback_output_tokens,
+            cache_read_input_tokens=0,
+            cache_write_input_tokens=0,
+            total_tokens=fallback_prompt_tokens + fallback_output_tokens,
+            ttft_ms=None,
+            tps=None,
+            actual_cost=actual_cost,
+            input_cost_multiplier=1.0,
+            cache_hit_ratio=0.0,
+        )
     return latest
 
 

--- a/uncommon_route/proxy.py
+++ b/uncommon_route/proxy.py
@@ -122,6 +122,8 @@ _debug_log = logging.getLogger("uncommon_route.debug_routing")
 
 DEFAULT_UPSTREAM = ""
 DEFAULT_PORT = int(os.environ.get("UNCOMMON_ROUTE_PORT", "8403"))
+_RECURSION_GUARD_HEADER = "x-uncommon-route-recursion-guard"
+_ORIGINAL_MODEL_HEADER = "x-uncommon-route-original-model"
 
 # Cross-provider safe ceiling for outgoing max_tokens. Upstream gateways cap
 # output below the model's native limit (e.g. GLM-4.6 via some gateways rejects
@@ -521,7 +523,7 @@ def _build_debug_response(prompt: str, system_prompt: str | None, routing_config
         lines.append("")
 
     lines.extend([
-        f"Scoring",
+        "Scoring",
         f"  Signals: {', '.join(result.signals)}",
         "",
         f"Tier Boundaries: SIMPLE <{tier_boundaries.simple_medium:.2f}"
@@ -585,6 +587,54 @@ def _extract_assistant_text(content: bytes) -> str:
                 parts.append(item.get("text", ""))
         return "\n".join(parts)
     return str(text)
+
+
+def _normalize_reasoning_content_chunk(raw: bytes) -> bytes:
+    """Mirror reasoning_content into content for clients that only read content."""
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return raw
+
+    lines = text.split("\n")
+    changed = False
+    for idx, line in enumerate(lines):
+        if not line.startswith("data:"):
+            continue
+        payload = line[5:].strip()
+        if not payload or payload == "[DONE]":
+            continue
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        choices = data.get("choices")
+        if not isinstance(choices, list) or not choices:
+            continue
+        first_choice = choices[0]
+        if not isinstance(first_choice, dict):
+            continue
+        delta = first_choice.get("delta")
+        if not isinstance(delta, dict):
+            continue
+        reasoning_content = delta.get("reasoning_content")
+        if reasoning_content and not delta.get("content"):
+            delta["content"] = reasoning_content
+            lines[idx] = f"data: {json.dumps(data, ensure_ascii=False)}"
+            changed = True
+    if not changed:
+        return raw
+    return "\n".join(lines).encode("utf-8")
+
+
+def _recursion_guard_enabled(request: Request) -> bool:
+    value = str(request.headers.get(_RECURSION_GUARD_HEADER, "")).strip().lower()
+    return value in {"1", "true", "yes", "on", "internal"}
+
+
+def _is_virtual_model_name(model: str) -> bool:
+    normalized = str(model or "").strip().lower()
+    return routing_mode_from_model(normalized) is not None
 
 
 class UpstreamSemanticCompressor:
@@ -3465,6 +3515,7 @@ def create_app(
         model = (body.get("model") or "").strip().lower()
         is_streaming = body.get("stream", False)
         response_model = str(body.pop("_client_requested_model", "") or model).strip()
+        recursion_guarded = _recursion_guard_enabled(request)
 
         if not model:
             default_mode = _routing_store.default_mode()
@@ -3473,6 +3524,14 @@ def create_app(
 
         requested_model = model
         routing_mode = routing_mode_from_model(model)
+        if recursion_guarded and routing_mode is not None:
+            msg = "Virtual UncommonRoute models cannot be routed recursively"
+            if api_format == "anthropic":
+                return JSONResponse(anthropic_error_response(400, msg), status_code=400)
+            return JSONResponse(
+                {"error": {"message": msg, "type": "invalid_request_error"}},
+                status_code=400,
+            )
         is_virtual = routing_mode is not None
         route_start = time.perf_counter_ns()
         route_method: str = "pool"
@@ -3597,7 +3656,6 @@ def create_app(
                 has_tools=bool(body.get("tools") or body.get("customTools")),
             )
             ctx_features = extract_context_features(body, step_type, prompt)
-            requirements = routing_features.request_requirements()
             hints = routing_features.workload_hints()
             step_type = routing_features.step_type
             user_keyed = _providers.keyed_models() or None
@@ -3733,6 +3791,15 @@ def create_app(
             except Exception:
                 pass
             selected_model = decision.model
+            if _is_virtual_model_name(selected_model):
+                msg = f"Router selected a virtual model recursively: {selected_model}"
+                logger.error(msg)
+                if api_format == "anthropic":
+                    return JSONResponse(anthropic_error_response(500, msg), status_code=500)
+                return JSONResponse(
+                    {"error": {"message": msg, "type": "routing_error"}},
+                    status_code=500,
+                )
             tier_value = decision.tier.value
             decision_tier = tier_value
             served_quality_value = decision.served_quality.value
@@ -3949,7 +4016,7 @@ def create_app(
             )
             fallback_models = [
                 fb.model for fb in decision.fallback_chain
-                if fb.model != selected_model
+                if fb.model != selected_model and not _is_virtual_model_name(fb.model)
             ]
         else:
             selected_model = model
@@ -4012,7 +4079,14 @@ def create_app(
             if isinstance(_requested_max, int) and _requested_max > UPSTREAM_MAX_OUTPUT_TOKENS:
                 attempt_upstream_body["max_tokens"] = UPSTREAM_MAX_OUTPUT_TOKENS
             attempt_headers: dict[str, str] = {}
-            for key in ("authorization", "content-type", "accept", "user-agent"):
+            for key in (
+                "authorization",
+                "content-type",
+                "accept",
+                "user-agent",
+                _RECURSION_GUARD_HEADER,
+                _ORIGINAL_MODEL_HEADER,
+            ):
                 val = request.headers.get(key)
                 if val:
                     attempt_headers[key] = val
@@ -4023,6 +4097,10 @@ def create_app(
             if "content-type" not in attempt_headers:
                 attempt_headers["content-type"] = "application/json"
             attempt_headers["user-agent"] = f"uncommon-route/{VERSION}"
+            if is_virtual and not attempt_provider_entry:
+                attempt_headers[_RECURSION_GUARD_HEADER] = "1"
+                if requested_model:
+                    attempt_headers[_ORIGINAL_MODEL_HEADER] = requested_model
 
             resolved_model = model_name
             if not attempt_provider_entry:
@@ -4850,7 +4928,7 @@ def create_app(
                     try:
                         async for chunk in stream_resp.aiter_bytes():
                             stream_chunks.append(chunk)
-                            yield chunk
+                            yield _normalize_reasoning_content_chunk(chunk)
                         await _record_stream_success(
                             parse_stream_usage_metrics(stream_chunks, selected_model, _get_pricing())
                         )

--- a/uncommon_route/router/selector.py
+++ b/uncommon_route/router/selector.py
@@ -1033,6 +1033,11 @@ def _dynamic_quality_alignment_weight(
     ):
         return max(base_weight, 0.22)
 
+    if target is ServedQuality.BALANCED and agent_pressure >= 0.55:
+        pressure = max(0.0, min(1.0, (agent_pressure - 0.55) / 0.45))
+        low_risk_pressure = 0.5 if normalized_step_risk == "low" else 1.0
+        return base_weight + (0.08 * pressure * low_risk_pressure)
+
     if tier is not Tier.COMPLEX or target is not ServedQuality.PREMIUM:
         return base_weight
 


### PR DESCRIPTION
## Summary

This PR rewrites the useful parts of the remaining open PRs into a smaller integration patch:

- sanitizes Anthropic tool_use IDs consistently across request, response, and streaming conversion
- mirrors OpenRouter-style `reasoning_content` into streaming `content` while preserving the original field, and records fallback stream usage metrics
- adds a proxy recursion guard for virtual UncommonRoute model names plus Docker packaging and docs
- adds dashboard dev proxy support for `/health` and `/v1`
- tightens high-pressure balanced routing fit and stabilizes the proxy-env doctor test

Large/stale PRs that change dashboard explain pages, init TUI/i18n, or scene routing are intentionally not merged as-is because they need smaller follow-up designs and security/privacy review.

## Validation

- `PYTHONPATH=/tmp/uncommon-route-test-deps:. pytest -q` -> 563 passed, 5 skipped
- `PYTHONPATH=/tmp/uncommon-route-test-deps:. pytest tests/test_proxy.py tests/test_anthropic_compat.py tests/test_cache_support.py tests/test_usage_modes.py::TestCLI::test_doctor_warns_when_proxy_env_can_break_local_proxy_access tests/test_v2_routing_logic.py -q` -> 163 passed
- `ruff check uncommon_route/anthropic_compat.py uncommon_route/cache_support.py uncommon_route/proxy.py uncommon_route/router/selector.py tests/test_anthropic_compat.py tests/test_cache_support.py tests/test_proxy.py tests/test_usage_modes.py` -> passed
- `npm run build` in `frontend/dashboard` -> passed
- `docker build -f docker/Dockerfile -t uncommon-route:pr-settle-test .` -> passed
- `docker run --rm uncommon-route:pr-settle-test uncommon-route --version` -> 0.7.15
- `PYTHONPATH=/tmp/uncommon-route-test-deps:. python -m uncommon_route.cli doctor` -> setup ready with OpenRouter upstream
- `PYTHONPATH=/tmp/uncommon-route-test-deps:. python -m uncommon_route.cli route --json --no-feedback ...` -> route decision succeeded