### PR TITLE
Merge named scene routing feature

### DIFF
--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -22,6 +22,7 @@ from uncommon_route.proxy import (
 )
 from uncommon_route.router.config import routing_mode_from_model
 from uncommon_route.routing_config_store import InMemoryRoutingConfigStorage, RoutingConfigStore
+import uncommon_route.scene_store as scene_store_module
 from uncommon_route.semantic import SemanticCallResult, SideChannelConfig, SideChannelTaskConfig
 from uncommon_route.spend_control import InMemorySpendControlStorage, SpendControl
 from uncommon_route.traces import InMemoryTraceStorage, TraceStore
@@ -998,6 +999,98 @@ class TestRoutingConfigEndpoint:
         assert reset_data["modes"]["auto"]["tiers"]["SIMPLE"]["fallback"] == []
         assert reset_data["modes"]["auto"]["tiers"]["SIMPLE"]["overridden"] is False
         assert reset_data["modes"]["auto"]["tiers"]["SIMPLE"]["selection_mode"] == "adaptive"
+
+
+class TestScenesEndpoint:
+    def test_post_scene_requires_admin_token(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(scene_store_module, "_SCENES_FILE", tmp_path / "scenes.json")
+        monkeypatch.setenv("UNCOMMON_ROUTE_ADMIN_TOKEN", "test-admin")
+        app = create_app(upstream="http://127.0.0.1:1/fake")
+        client = TestClient(app, raise_server_exceptions=False)
+
+        denied = client.post("/v1/scenes", json={
+            "action": "add",
+            "name": "coding",
+            "primary": "anthropic/claude-sonnet-4.6",
+        })
+        assert denied.status_code == 401
+
+        allowed = client.post(
+            "/v1/scenes",
+            headers={"authorization": "Bearer test-admin"},
+            json={
+                "action": "add",
+                "name": "coding",
+                "primary": "anthropic/claude-sonnet-4.6",
+            },
+        )
+        assert allowed.status_code == 200
+        assert allowed.json()["scene"]["name"] == "coding"
+
+    def test_header_scene_routes_real_model_through_hard_pin(
+        self,
+        tmp_path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(scene_store_module, "_SCENES_FILE", tmp_path / "scenes.json")
+        monkeypatch.setenv("UNCOMMON_ROUTE_ADMIN_TOKEN", "test-admin")
+        posted_models: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content.decode("utf-8"))
+            posted_models.append(str(body.get("model")))
+            return httpx.Response(200, json={
+                "id": "chatcmpl_scene",
+                "object": "chat.completion",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop",
+                }],
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            })
+
+        async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        monkeypatch.setattr("uncommon_route.proxy._get_client", lambda: async_client)
+
+        try:
+            app = create_app(
+                upstream="https://api.example.test/v1",
+                spend_control=SpendControl(storage=InMemorySpendControlStorage()),
+            )
+            client = TestClient(app, raise_server_exceptions=False)
+            scene = client.post(
+                "/v1/scenes",
+                headers={"authorization": "Bearer test-admin"},
+                json={
+                    "action": "add",
+                    "name": "private",
+                    "primary": "anthropic/claude-opus-4.6",
+                    "hard_pin": True,
+                },
+            )
+            assert scene.status_code == 200
+
+            resp = client.post(
+                "/v1/chat/completions",
+                headers={"x-uncommon-route-scene": "private"},
+                json={
+                    "model": "openai/gpt-4o-mini",
+                    "messages": [{"role": "user", "content": "hello"}],
+                },
+            )
+
+            assert resp.status_code == 200
+            assert posted_models == ["claude-opus-4.6"]
+            assert resp.headers["x-uncommon-route-mode"] == "auto"
+            assert resp.headers["x-uncommon-route-model"] == "anthropic/claude-opus-4.6"
+            assert resp.headers["x-uncommon-route-method"] == "scene:private:hard-pin"
+        finally:
+            asyncio.run(async_client.aclose())
 
 
 class TestChatCompletions:

--- a/tests/test_scene_store.py
+++ b/tests/test_scene_store.py
@@ -1,0 +1,200 @@
+"""Tests for scene_store — named routing scenes."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from uncommon_route.scene_store import SceneConfig, SceneStore, _serialize_scene, _deserialize_scene
+from uncommon_route.router.types import Tier
+
+
+class TestSceneConfig:
+    def test_model_pool_deduplicates(self):
+        scene = SceneConfig(
+            name="test",
+            primary="anthropic/claude-opus-4.6",
+            fallback=["anthropic/claude-sonnet-4.6", "anthropic/claude-opus-4.6", "openai/gpt-5.2"],
+        )
+        pool = scene.model_pool()
+        assert pool == [
+            "anthropic/claude-opus-4.6",
+            "anthropic/claude-sonnet-4.6",
+            "openai/gpt-5.2",
+        ]
+
+    def test_model_pool_strips_whitespace(self):
+        scene = SceneConfig(name="t", primary=" anthropic/opus ", fallback=[" google/gemini "])
+        pool = scene.model_pool()
+        assert pool == ["anthropic/opus", "google/gemini"]
+
+    def test_model_pool_empty_fallback(self):
+        scene = SceneConfig(name="t", primary="a/b")
+        assert scene.model_pool() == ["a/b"]
+
+    def test_as_routing_constraints(self):
+        scene = SceneConfig(
+            name="test",
+            primary="a/b",
+            fallback=["c/d"],
+            allowed_providers=["anthropic"],
+            max_cost_per_request=0.05,
+        )
+        constraints = scene.as_routing_constraints()
+        assert constraints.allowed_models == ("a/b", "c/d")
+        assert constraints.allowed_providers == ("anthropic",)
+        assert constraints.max_cost == 0.05
+
+    def test_as_selection_weights_none_by_default(self):
+        scene = SceneConfig(name="t", primary="a/b")
+        assert scene.as_selection_weights() is None
+
+    def test_as_selection_weights_override(self):
+        scene = SceneConfig(
+            name="t",
+            primary="a/b",
+            selection_weights_override={"editorial": 0.8, "cost": 0.1},
+        )
+        weights = scene.as_selection_weights()
+        assert weights is not None
+        assert weights.editorial == 0.8
+        assert weights.cost == 0.1
+        # Unspecified fields use defaults
+        assert weights.latency == 0.1
+
+
+class TestSerialization:
+    def test_roundtrip(self):
+        scene = SceneConfig(
+            name="intimate",
+            primary="anthropic/claude-opus-4.6",
+            fallback=["anthropic/claude-sonnet-4.6"],
+            hard_pin=True,
+            description="Private chat with BB",
+            tier_floor=Tier.COMPLEX,
+        )
+        data = _serialize_scene(scene)
+        restored = _deserialize_scene(data)
+        assert restored is not None
+        assert restored.name == "intimate"
+        assert restored.primary == "anthropic/claude-opus-4.6"
+        assert restored.hard_pin is True
+        assert restored.tier_floor == Tier.COMPLEX
+
+    def test_deserialize_invalid_returns_none(self):
+        assert _deserialize_scene({}) is None
+        assert _deserialize_scene({"name": "x"}) is None  # missing primary
+        assert _deserialize_scene({"primary": "x"}) is None  # missing name
+
+    def test_deserialize_normalizes_name(self):
+        scene = _deserialize_scene({"name": "  INTIMATE  ", "primary": "a/b"})
+        assert scene is not None
+        assert scene.name == "intimate"
+
+    def test_tier_enum_serialization(self):
+        scene = SceneConfig(name="t", primary="a/b", tier_floor=Tier.MEDIUM, tier_cap=Tier.COMPLEX)
+        data = _serialize_scene(scene)
+        assert data.get("tier_floor") == "MEDIUM"
+        assert data.get("tier_cap") == "COMPLEX"
+
+
+class TestSceneStore:
+    def _make_store(self, tmp_path: Path) -> SceneStore:
+        return SceneStore(path=tmp_path / "scenes.json")
+
+    def test_add_and_get(self, tmp_path):
+        store = self._make_store(tmp_path)
+        scene = SceneConfig(name="intimate", primary="anthropic/claude-opus-4.6", hard_pin=True)
+        stored = store.add(scene)
+        assert stored.name == "intimate"
+        assert stored.hard_pin is True
+
+        fetched = store.get("intimate")
+        assert fetched is not None
+        assert fetched.primary == "anthropic/claude-opus-4.6"
+
+    def test_get_case_insensitive(self, tmp_path):
+        store = self._make_store(tmp_path)
+        store.add(SceneConfig(name="Intimate", primary="a/b"))
+        assert store.get("intimate") is not None
+        assert store.get("INTIMATE") is not None
+
+    def test_remove(self, tmp_path):
+        store = self._make_store(tmp_path)
+        store.add(SceneConfig(name="test", primary="a/b"))
+        assert store.remove("test") is True
+        assert store.get("test") is None
+        assert store.remove("nonexistent") is False
+
+    def test_list_sorted(self, tmp_path):
+        store = self._make_store(tmp_path)
+        store.add(SceneConfig(name="cron", primary="a/b"))
+        store.add(SceneConfig(name="alpha", primary="c/d"))
+        store.add(SceneConfig(name="work", primary="e/f"))
+        names = [s.name for s in store.list()]
+        assert names == ["alpha", "cron", "work"]
+
+    def test_persistence(self, tmp_path):
+        path = tmp_path / "scenes.json"
+        store1 = SceneStore(path=path)
+        store1.add(SceneConfig(name="intimate", primary="a/opus", hard_pin=True))
+        store1.add(SceneConfig(name="crew", primary="g/flash"))
+
+        # New store instance reads from same file
+        store2 = SceneStore(path=path)
+        assert store2.get("intimate") is not None
+        assert store2.get("intimate").hard_pin is True
+        assert store2.get("crew") is not None
+        assert len(store2.list()) == 2
+
+    def test_add_deduplicates_fallback(self, tmp_path):
+        store = self._make_store(tmp_path)
+        scene = SceneConfig(
+            name="test",
+            primary="a/opus",
+            fallback=["a/sonnet", "a/opus", "a/haiku"],  # opus is duplicate of primary
+        )
+        stored = store.add(scene)
+        assert "a/opus" not in stored.fallback
+        assert stored.fallback == ["a/sonnet", "a/haiku"]
+
+    def test_resolve_missing_returns_none(self, tmp_path):
+        store = self._make_store(tmp_path)
+        assert store.resolve("nonexistent") is None
+
+    def test_resolve_existing_returns_scene(self, tmp_path):
+        store = self._make_store(tmp_path)
+        store.add(SceneConfig(name="intimate", primary="a/b"))
+        resolved = store.resolve("intimate")
+        assert resolved is not None
+        assert resolved.name == "intimate"
+
+    def test_corrupt_file_handled_gracefully(self, tmp_path):
+        path = tmp_path / "scenes.json"
+        path.write_text("not valid json {{{")
+        store = SceneStore(path=path)
+        assert len(store.list()) == 0
+
+    def test_export_import_roundtrip(self, tmp_path):
+        store1 = self._make_store(tmp_path)
+        store1.add(SceneConfig(name="a", primary="x/y"))
+        store1.add(SceneConfig(name="b", primary="z/w", hard_pin=True))
+        exported = store1.export()
+
+        store2 = self._make_store(tmp_path / "other")
+        count = store2.import_scenes(exported)
+        assert count == 2
+        assert store2.get("a") is not None
+        assert store2.get("b").hard_pin is True
+
+    def test_update_existing_scene(self, tmp_path):
+        store = self._make_store(tmp_path)
+        store.add(SceneConfig(name="test", primary="a/b"))
+        store.add(SceneConfig(name="test", primary="c/d", hard_pin=True))
+        scene = store.get("test")
+        assert scene.primary == "c/d"
+        assert scene.hard_pin is True
+        assert len(store.list()) == 1  # Not duplicated

--- a/tests/test_scene_store.py
+++ b/tests/test_scene_store.py
@@ -48,22 +48,10 @@ class TestSceneConfig:
         assert constraints.allowed_providers == ("anthropic",)
         assert constraints.max_cost == 0.05
 
-    def test_as_selection_weights_none_by_default(self):
+    def test_as_selection_weights_returns_none(self):
+        """selection_weights_override removed; method reserved for future use."""
         scene = SceneConfig(name="t", primary="a/b")
         assert scene.as_selection_weights() is None
-
-    def test_as_selection_weights_override(self):
-        scene = SceneConfig(
-            name="t",
-            primary="a/b",
-            selection_weights_override={"editorial": 0.8, "cost": 0.1},
-        )
-        weights = scene.as_selection_weights()
-        assert weights is not None
-        assert weights.editorial == 0.8
-        assert weights.cost == 0.1
-        # Unspecified fields use defaults
-        assert weights.latency == 0.1
 
 
 class TestSerialization:

--- a/tests/test_scene_store.py
+++ b/tests/test_scene_store.py
@@ -1,0 +1,184 @@
+"""Tests for scene_store — named routing scenes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from uncommon_route.router.types import Tier
+from uncommon_route.scene_store import SceneConfig, SceneStore, _deserialize_scene, _serialize_scene
+
+
+class TestSceneConfig:
+    def test_model_pool_deduplicates(self):
+        scene = SceneConfig(
+            name="test",
+            primary="anthropic/claude-opus-4.6",
+            fallback=["anthropic/claude-sonnet-4.6", "anthropic/claude-opus-4.6", "openai/gpt-5.2"],
+        )
+        pool = scene.model_pool()
+        assert pool == [
+            "anthropic/claude-opus-4.6",
+            "anthropic/claude-sonnet-4.6",
+            "openai/gpt-5.2",
+        ]
+
+    def test_model_pool_strips_whitespace(self):
+        scene = SceneConfig(name="t", primary=" anthropic/opus ", fallback=[" google/gemini "])
+        pool = scene.model_pool()
+        assert pool == ["anthropic/opus", "google/gemini"]
+
+    def test_model_pool_empty_fallback(self):
+        scene = SceneConfig(name="t", primary="a/b")
+        assert scene.model_pool() == ["a/b"]
+
+    def test_as_routing_constraints(self):
+        scene = SceneConfig(
+            name="test",
+            primary="a/b",
+            fallback=["c/d"],
+            allowed_providers=["anthropic"],
+            max_cost_per_request=0.05,
+        )
+        constraints = scene.as_routing_constraints()
+        assert constraints.allowed_models == ("a/b", "c/d")
+        assert constraints.allowed_providers == ("anthropic",)
+        assert constraints.max_cost == 0.05
+
+    def test_as_selection_weights_returns_none(self):
+        """selection_weights_override removed; method reserved for future use."""
+        scene = SceneConfig(name="t", primary="a/b")
+        assert scene.as_selection_weights() is None
+
+
+class TestSerialization:
+    def test_roundtrip(self):
+        scene = SceneConfig(
+            name="intimate",
+            primary="anthropic/claude-opus-4.6",
+            fallback=["anthropic/claude-sonnet-4.6"],
+            hard_pin=True,
+            description="Private chat with BB",
+            tier_floor=Tier.COMPLEX,
+        )
+        data = _serialize_scene(scene)
+        restored = _deserialize_scene(data)
+        assert restored is not None
+        assert restored.name == "intimate"
+        assert restored.primary == "anthropic/claude-opus-4.6"
+        assert restored.hard_pin is True
+        assert restored.tier_floor == Tier.COMPLEX
+
+    def test_deserialize_invalid_returns_none(self):
+        assert _deserialize_scene({}) is None
+        assert _deserialize_scene({"name": "x"}) is None  # missing primary
+        assert _deserialize_scene({"primary": "x"}) is None  # missing name
+
+    def test_deserialize_normalizes_name(self):
+        scene = _deserialize_scene({"name": "  INTIMATE  ", "primary": "a/b"})
+        assert scene is not None
+        assert scene.name == "intimate"
+
+    def test_tier_enum_serialization(self):
+        scene = SceneConfig(name="t", primary="a/b", tier_floor=Tier.MEDIUM, tier_cap=Tier.COMPLEX)
+        data = _serialize_scene(scene)
+        assert data.get("tier_floor") == "MEDIUM"
+        assert data.get("tier_cap") == "COMPLEX"
+
+
+class TestSceneStore:
+    def _make_store(self, tmp_path: Path) -> SceneStore:
+        return SceneStore(path=tmp_path / "scenes.json")
+
+    def test_add_and_get(self, tmp_path):
+        store = self._make_store(tmp_path)
+        scene = SceneConfig(name="intimate", primary="anthropic/claude-opus-4.6", hard_pin=True)
+        stored = store.add(scene)
+        assert stored.name == "intimate"
+        assert stored.hard_pin is True
+
+        fetched = store.get("intimate")
+        assert fetched is not None
+        assert fetched.primary == "anthropic/claude-opus-4.6"
+
+    def test_get_case_insensitive(self, tmp_path):
+        store = self._make_store(tmp_path)
+        store.add(SceneConfig(name="Intimate", primary="a/b"))
+        assert store.get("intimate") is not None
+        assert store.get("INTIMATE") is not None
+
+    def test_remove(self, tmp_path):
+        store = self._make_store(tmp_path)
+        store.add(SceneConfig(name="test", primary="a/b"))
+        assert store.remove("test") is True
+        assert store.get("test") is None
+        assert store.remove("nonexistent") is False
+
+    def test_list_sorted(self, tmp_path):
+        store = self._make_store(tmp_path)
+        store.add(SceneConfig(name="cron", primary="a/b"))
+        store.add(SceneConfig(name="alpha", primary="c/d"))
+        store.add(SceneConfig(name="work", primary="e/f"))
+        names = [s.name for s in store.list()]
+        assert names == ["alpha", "cron", "work"]
+
+    def test_persistence(self, tmp_path):
+        path = tmp_path / "scenes.json"
+        store1 = SceneStore(path=path)
+        store1.add(SceneConfig(name="intimate", primary="a/opus", hard_pin=True))
+        store1.add(SceneConfig(name="crew", primary="g/flash"))
+
+        # New store instance reads from same file
+        store2 = SceneStore(path=path)
+        assert store2.get("intimate") is not None
+        assert store2.get("intimate").hard_pin is True
+        assert store2.get("crew") is not None
+        assert len(store2.list()) == 2
+
+    def test_add_deduplicates_fallback(self, tmp_path):
+        store = self._make_store(tmp_path)
+        scene = SceneConfig(
+            name="test",
+            primary="a/opus",
+            fallback=["a/sonnet", "a/opus", "a/haiku"],  # opus is duplicate of primary
+        )
+        stored = store.add(scene)
+        assert "a/opus" not in stored.fallback
+        assert stored.fallback == ["a/sonnet", "a/haiku"]
+
+    def test_resolve_missing_returns_none(self, tmp_path):
+        store = self._make_store(tmp_path)
+        assert store.resolve("nonexistent") is None
+
+    def test_resolve_existing_returns_scene(self, tmp_path):
+        store = self._make_store(tmp_path)
+        store.add(SceneConfig(name="intimate", primary="a/b"))
+        resolved = store.resolve("intimate")
+        assert resolved is not None
+        assert resolved.name == "intimate"
+
+    def test_corrupt_file_handled_gracefully(self, tmp_path):
+        path = tmp_path / "scenes.json"
+        path.write_text("not valid json {{{")
+        store = SceneStore(path=path)
+        assert len(store.list()) == 0
+
+    def test_export_import_roundtrip(self, tmp_path):
+        store1 = self._make_store(tmp_path)
+        store1.add(SceneConfig(name="a", primary="x/y"))
+        store1.add(SceneConfig(name="b", primary="z/w", hard_pin=True))
+        exported = store1.export()
+
+        store2 = self._make_store(tmp_path / "other")
+        count = store2.import_scenes(exported)
+        assert count == 2
+        assert store2.get("a") is not None
+        assert store2.get("b").hard_pin is True
+
+    def test_update_existing_scene(self, tmp_path):
+        store = self._make_store(tmp_path)
+        store.add(SceneConfig(name="test", primary="a/b"))
+        store.add(SceneConfig(name="test", primary="c/d", hard_pin=True))
+        scene = store.get("test")
+        assert scene.primary == "c/d"
+        assert scene.hard_pin is True
+        assert len(store.list()) == 1  # Not duplicated

--- a/tests/test_usage_modes.py
+++ b/tests/test_usage_modes.py
@@ -105,6 +105,27 @@ class TestCLI:
         assert r.returncode == 0
         assert "Usage: uncommon-route init" in r.stdout
 
+    def test_scene_add_and_show(self, tmp_path: Path) -> None:
+        env = {"UNCOMMON_ROUTE_DATA_DIR": str(tmp_path / ".uncommon-route")}
+
+        add = run_cli(
+            [
+                "scene",
+                "add",
+                "coding",
+                "anthropic/claude-sonnet-4.6",
+                "openai/gpt-5.2",
+            ],
+            env=env,
+        )
+        assert add.returncode == 0
+
+        show = run_cli(["scene", "show", "coding"], env=env)
+        assert show.returncode == 0
+        assert "Scene: coding" in show.stdout
+        assert "Primary: anthropic/claude-sonnet-4.6" in show.stdout
+        assert "Model pool: anthropic/claude-sonnet-4.6 -> openai/gpt-5.2" in show.stdout
+
     def test_route_text(self) -> None:
         r = run_cli(["route", "what is 2+2"])
         assert r.returncode == 0

--- a/uncommon_route/cli.py
+++ b/uncommon_route/cli.py
@@ -1071,6 +1071,116 @@ def _setup_openai(args: list[str]) -> None:
 
 
 
+def _cmd_scene(args: list[str]) -> None:
+    """Manage named routing scenes."""
+    if not args:
+        print("Usage: uncommon-route scene <action>", file=sys.stderr)
+        print("  Actions: list, add, remove, show", file=sys.stderr)
+        sys.exit(1)
+
+    from uncommon_route.scene_store import SceneStore, SceneConfig
+
+    store = SceneStore()
+    action = args[0].lower()
+
+    if action == "list":
+        scenes = store.list()
+        if not scenes:
+            print("No scenes configured.")
+            print("  Add one: uncommon-route scene add intimate anthropic/claude-opus-4.6 --hard-pin")
+            return
+        for scene in scenes:
+            pin_label = " [hard-pin]" if scene.hard_pin else " [adaptive]"
+            desc = f"  ({scene.description})" if scene.description else ""
+            fallback_str = f" → {', '.join(scene.fallback)}" if scene.fallback else ""
+            print(f"  {scene.name}: {scene.primary}{fallback_str}{pin_label}{desc}")
+
+    elif action == "add":
+        if len(args) < 3:
+            print("Usage: uncommon-route scene add <name> <primary> [fallback...] [--hard-pin] [--description 'desc']", file=sys.stderr)
+            sys.exit(1)
+        name = args[1]
+        primary = args[2]
+        fallback = []
+        hard_pin = False
+        description = ""
+        i = 3
+        while i < len(args):
+            if args[i] == "--hard-pin":
+                hard_pin = True
+                i += 1
+            elif args[i] == "--description" and i + 1 < len(args):
+                description = args[i + 1]
+                i += 2
+            elif args[i] == "--fallback":
+                i += 1
+                while i < len(args) and not args[i].startswith("--"):
+                    fallback.append(args[i])
+                    i += 1
+            elif not args[i].startswith("--"):
+                fallback.append(args[i])
+                i += 1
+            else:
+                i += 1
+
+        scene = SceneConfig(
+            name=name,
+            primary=primary,
+            fallback=fallback,
+            hard_pin=hard_pin,
+            description=description,
+        )
+        stored = store.add(scene)
+        pin_label = "hard-pin" if stored.hard_pin else "adaptive"
+        print(f"Scene '{stored.name}' saved: {stored.primary} [{pin_label}]")
+        if stored.fallback:
+            print(f"  Fallback: {', '.join(stored.fallback)}")
+
+    elif action == "remove":
+        if len(args) < 2:
+            print("Usage: uncommon-route scene remove <name>", file=sys.stderr)
+            sys.exit(1)
+        name = args[1]
+        if store.remove(name):
+            print(f"Scene '{name}' removed.")
+        else:
+            print(f"Scene '{name}' not found.", file=sys.stderr)
+            sys.exit(1)
+
+    elif action == "show":
+        if len(args) < 2:
+            print("Usage: uncommon-route scene show <name>", file=sys.stderr)
+            sys.exit(1)
+        name = args[1]
+        scene = store.get(name)
+        if not scene:
+            print(f"Scene '{name}' not found.", file=sys.stderr)
+            sys.exit(1)
+        print(f"Scene: {scene.name}")
+        print(f"  Primary: {scene.primary}")
+        if scene.fallback:
+            print(f"  Fallback: {', '.join(scene.fallback)}")
+        print(f"  Mode: {'hard-pin' if scene.hard_pin else 'adaptive'}")
+        if scene.description:
+            print(f"  Description: {scene.description}")
+        if scene.complexity_override is not None:
+            print(f"  Complexity override: {scene.complexity_override}")
+        if scene.tier_floor:
+            print(f"  Tier floor: {scene.tier_floor.value}")
+        if scene.tier_cap:
+            print(f"  Tier cap: {scene.tier_cap.value}")
+        if scene.allowed_providers:
+            print(f"  Allowed providers: {', '.join(scene.allowed_providers)}")
+        if scene.max_cost_per_request is not None:
+            print(f"  Max cost/req: ${scene.max_cost_per_request:.4f}")
+        print(f"  Model pool: {' → '.join(scene.model_pool())}")
+
+    else:
+        print(f"Unknown scene action: {action}", file=sys.stderr)
+        print("  Actions: list, add, remove, show", file=sys.stderr)
+        sys.exit(1)
+
+
 def main() -> None:
     args = sys.argv[1:]
 
@@ -1099,6 +1209,7 @@ def main() -> None:
         "config": _cmd_config,
         "stats": _cmd_stats,
         "feedback": _cmd_feedback,
+        "scene": _cmd_scene,
     }
 
     handler = commands.get(cmd)

--- a/uncommon_route/cli.py
+++ b/uncommon_route/cli.py
@@ -124,6 +124,12 @@ Stats subcommands:
   stats history [--limit <n>]         Recent routing decisions
   stats reset                         Clear all stats
 
+Scene subcommands:
+  scene list                          List named routing scenes
+  scene add <name> <primary> [...]    Add or update a routing scene
+  scene show <name>                   Show one routing scene
+  scene remove <name>                 Remove one routing scene
+
 Config subcommands:
   config show [--json]                Show active default mode and tier overrides
   config set-default-mode <mode>      Set the default mode used when no model is specified
@@ -148,6 +154,7 @@ Examples:
   uncommon-route support bundle
   uncommon-route spend set hourly 5.00
   uncommon-route provider add deepseek sk-...
+  uncommon-route scene add coding anthropic/claude-sonnet-4.6 openai/gpt-5.2
   uncommon-route config set-default-mode fast
   uncommon-route config set-tier auto SIMPLE openai/gpt-4o-mini --fallback moonshot/kimi-k2.5 --strategy hard-pin
 """)
@@ -263,6 +270,20 @@ Classify a prompt and show the routing decision without sending it upstream.
 """)
 
 
+def _print_scene_help() -> None:
+    print("""Usage: uncommon-route scene <list|add|show|remove> [...]
+
+Manage named routing scenes.
+
+Examples:
+  uncommon-route scene list
+  uncommon-route scene add coding anthropic/claude-sonnet-4.6 openai/gpt-5.2
+  uncommon-route scene add private anthropic/claude-opus-4.6 --hard-pin --description "private chat"
+  uncommon-route scene show coding
+  uncommon-route scene remove coding
+""")
+
+
 def _print_generic_subcommand_help(cmd: str) -> None:
     printers = {
         "init": _print_init_help,
@@ -273,6 +294,7 @@ def _print_generic_subcommand_help(cmd: str) -> None:
         "support": _print_support_help,
         "provider": _print_provider_help,
         "route": _print_route_help,
+        "scene": _print_scene_help,
     }
     printer = printers.get(cmd, _print_help)
     printer()
@@ -1779,6 +1801,116 @@ def _setup_openai(args: list[str]) -> None:
 """)
     print(f"  Status: {status}")
 
+def _cmd_scene(args: list[str]) -> None:
+    """Manage named routing scenes."""
+    if not args:
+        print("Usage: uncommon-route scene <action>", file=sys.stderr)
+        print("  Actions: list, add, remove, show", file=sys.stderr)
+        sys.exit(1)
+
+    from uncommon_route.scene_store import SceneConfig, SceneStore
+
+    store = SceneStore()
+    action = args[0].lower()
+
+    if action == "list":
+        scenes = store.list()
+        if not scenes:
+            print("No scenes configured.")
+            print("  Add one: uncommon-route scene add intimate anthropic/claude-opus-4.6 --hard-pin")
+            return
+        for scene in scenes:
+            pin_label = " [hard-pin]" if scene.hard_pin else " [adaptive]"
+            desc = f"  ({scene.description})" if scene.description else ""
+            fallback_str = f" -> {', '.join(scene.fallback)}" if scene.fallback else ""
+            print(f"  {scene.name}: {scene.primary}{fallback_str}{pin_label}{desc}")
+
+    elif action == "add":
+        if len(args) < 3:
+            print(
+                "Usage: uncommon-route scene add <name> <primary> [fallback...] "
+                "[--hard-pin] [--description 'desc']",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        name = args[1]
+        primary = args[2]
+        fallback = []
+        hard_pin = False
+        description = ""
+        i = 3
+        while i < len(args):
+            if args[i] == "--hard-pin":
+                hard_pin = True
+                i += 1
+            elif args[i] == "--description" and i + 1 < len(args):
+                description = args[i + 1]
+                i += 2
+            elif args[i] == "--fallback":
+                i += 1
+                while i < len(args) and not args[i].startswith("--"):
+                    fallback.append(args[i])
+                    i += 1
+            elif not args[i].startswith("--"):
+                fallback.append(args[i])
+                i += 1
+            else:
+                i += 1
+
+        scene = SceneConfig(
+            name=name,
+            primary=primary,
+            fallback=fallback,
+            hard_pin=hard_pin,
+            description=description,
+        )
+        stored = store.add(scene)
+        pin_label = "hard-pin" if stored.hard_pin else "adaptive"
+        print(f"Scene '{stored.name}' saved: {stored.primary} [{pin_label}]")
+        if stored.fallback:
+            print(f"  Fallback: {', '.join(stored.fallback)}")
+
+    elif action == "remove":
+        if len(args) < 2:
+            print("Usage: uncommon-route scene remove <name>", file=sys.stderr)
+            sys.exit(1)
+        name = args[1]
+        if store.remove(name):
+            print(f"Scene '{name}' removed.")
+        else:
+            print(f"Scene '{name}' not found.", file=sys.stderr)
+            sys.exit(1)
+
+    elif action == "show":
+        if len(args) < 2:
+            print("Usage: uncommon-route scene show <name>", file=sys.stderr)
+            sys.exit(1)
+        name = args[1]
+        scene = store.get(name)
+        if not scene:
+            print(f"Scene '{name}' not found.", file=sys.stderr)
+            sys.exit(1)
+        print(f"Scene: {scene.name}")
+        print(f"  Primary: {scene.primary}")
+        if scene.fallback:
+            print(f"  Fallback: {', '.join(scene.fallback)}")
+        print(f"  Mode: {'hard-pin' if scene.hard_pin else 'adaptive'}")
+        if scene.description:
+            print(f"  Description: {scene.description}")
+        if scene.tier_floor:
+            print(f"  Tier floor: {scene.tier_floor.value}")
+        if scene.tier_cap:
+            print(f"  Tier cap: {scene.tier_cap.value}")
+        if scene.allowed_providers:
+            print(f"  Allowed providers: {', '.join(scene.allowed_providers)}")
+        if scene.max_cost_per_request is not None:
+            print(f"  Max cost/req: ${scene.max_cost_per_request:.4f}")
+        print(f"  Model pool: {' -> '.join(scene.model_pool())}")
+
+    else:
+        print(f"Unknown scene action: {action}", file=sys.stderr)
+        print("  Actions: list, add, remove, show", file=sys.stderr)
+        sys.exit(1)
 
 
 def _cmd_telemetry(args: list[str]) -> None:
@@ -1896,6 +2028,7 @@ def main() -> None:
         "explain": _cmd_explain,
         "telemetry": _cmd_telemetry,
         "traces": _cmd_traces,
+        "scene": _cmd_scene,
     }
 
     handler = commands.get(cmd)

--- a/uncommon_route/proxy.py
+++ b/uncommon_route/proxy.py
@@ -78,6 +78,7 @@ from uncommon_route.providers import (
 )
 from uncommon_route.model_map import ModelMapper
 from uncommon_route.routing_config_store import RoutingConfigStore
+from uncommon_route.scene_store import SceneConfig, SceneStore
 from uncommon_route.connections_store import ConnectionsStore, mask_api_key, resolve_primary_connection
 from uncommon_route.anthropic_compat import (
     anthropic_to_openai_request,
@@ -1004,6 +1005,7 @@ def create_app(
     _semantic = semantic_compressor
     _routing_store = routing_config_store or RoutingConfigStore()
     _routing_config = _routing_store.config()
+    _scene_store = SceneStore()
 
     def _upstream_chat_url(base_url: str) -> str:
         return f"{str(base_url or '').rstrip('/')}/chat/completions"
@@ -1607,6 +1609,71 @@ def create_app(
         _refresh_active_pricing()
         return JSONResponse(payload)
 
+    async def handle_scenes(request: Request) -> JSONResponse:
+        """GET /v1/scenes — list all scenes.  POST /v1/scenes — add/remove/import."""
+        if request.method == "GET":
+            return JSONResponse(_scene_store.export())
+
+        body = await request.json()
+        action = str(body.get("action", "")).strip().lower()
+        try:
+            if action == "add":
+                name = str(body.get("name", "")).strip()
+                primary = str(body.get("primary", "")).strip()
+                if not name or not primary:
+                    return JSONResponse({"error": "name and primary are required"}, status_code=400)
+                fallback_raw = body.get("fallback", [])
+                if isinstance(fallback_raw, str):
+                    fallback = [p.strip() for p in fallback_raw.split(",") if p.strip()]
+                elif isinstance(fallback_raw, list):
+                    fallback = [str(f).strip() for f in fallback_raw if str(f).strip()]
+                else:
+                    fallback = []
+                scene = SceneConfig(
+                    name=name,
+                    primary=primary,
+                    fallback=fallback,
+                    hard_pin=bool(body.get("hard_pin", False)),
+                    description=str(body.get("description", "")),
+                    complexity_override=body.get("complexity_override"),
+                    allowed_providers=body.get("allowed_providers", []),
+                    selection_weights_override=body.get("selection_weights_override"),
+                    max_cost_per_request=body.get("max_cost_per_request"),
+                )
+                stored = _scene_store.add(scene)
+                return JSONResponse({"ok": True, "scene": _serialize_scene_response(stored)})
+            elif action == "remove":
+                name = str(body.get("name", "")).strip()
+                if not name:
+                    return JSONResponse({"error": "name is required"}, status_code=400)
+                removed = _scene_store.remove(name)
+                return JSONResponse({"ok": removed, "name": name})
+            elif action == "import":
+                data = body.get("data", {})
+                count = _scene_store.import_scenes(data)
+                return JSONResponse({"ok": True, "imported": count})
+            else:
+                return JSONResponse(
+                    {"error": "Invalid action", "allowed": ["add", "remove", "import"]},
+                    status_code=400,
+                )
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+
+    async def handle_scene_detail(request: Request) -> JSONResponse:
+        """GET /v1/scenes/<name> — get one scene."""
+        name = request.path_params["name"]
+        scene = _scene_store.get(name)
+        if scene is None:
+            return JSONResponse({"error": f"Scene '{name}' not found"}, status_code=404)
+        return JSONResponse(_serialize_scene_response(scene))
+
+    def _serialize_scene_response(scene: SceneConfig) -> dict:
+        from uncommon_route.scene_store import _serialize_scene
+        data = _serialize_scene(scene)
+        data["model_pool"] = scene.model_pool()
+        return data
+
     async def handle_artifacts(request: Request) -> JSONResponse:
         limit = int(request.query_params.get("limit", "50"))
         return JSONResponse({
@@ -1731,6 +1798,36 @@ def create_app(
         session_id = _resolve_session_id(request, body)
         step_type, tool_names = _classify_step(body)
 
+        # ── Scene resolution ───────────────────────────────────────────
+        # Trigger precedence:
+        #   1. x-uncommon-route-scene header
+        #   2. Virtual model ID: uncommon-route/scene/<name>
+        #   3. (Future: OpenClaw session → scene mapping via plugin)
+        _scene_name: str | None = None
+        _active_scene: SceneConfig | None = None
+
+        # Check header first (highest priority)
+        _scene_header = request.headers.get("x-uncommon-route-scene", "").strip()
+        if _scene_header:
+            _scene_name = _scene_header
+
+        # Check virtual model ID: uncommon-route/scene/<name>
+        if not _scene_name and model.startswith("uncommon-route/scene/"):
+            _scene_name = model[len("uncommon-route/scene/"):].strip()
+            # Treat scene requests as virtual (need routing)
+            if not is_virtual:
+                is_virtual = True
+                routing_mode = RoutingMode.AUTO
+
+        if _scene_name:
+            _active_scene = _scene_store.resolve(_scene_name)
+            if _active_scene:
+                logger.info(
+                    "Scene '%s' active: primary=%s hard_pin=%s",
+                    _active_scene.name, _active_scene.primary, _active_scene.hard_pin,
+                )
+                route_method = f"scene:{_active_scene.name}"
+
         if is_virtual:
             if prompt.startswith("/debug"):
                 debug_prompt = prompt[len("/debug"):].strip() or "hello"
@@ -1741,20 +1838,84 @@ def create_app(
 
             requirements, hints = _extract_requirements(body, step_type)
             user_keyed = _providers.keyed_models() or None
-            decision = route(
-                prompt,
-                system_prompt,
-                max_tokens,
-                config=_routing_config,
-                routing_mode=routing_mode or RoutingMode.AUTO,
-                request_requirements=requirements,
-                workload_hints=hints,
-                user_keyed_models=user_keyed,
-                model_experience=_model_experience,
-                pricing=_get_pricing(),
-                available_models=_mapper.available_models if _mapper.discovered else None,
-                model_capabilities=_routing_config.model_capabilities,
-            )
+
+            # ── Scene-aware routing ──────────────────────────────────
+            if _active_scene and _active_scene.hard_pin:
+                # Hard-pin: bypass classifier AND selector entirely.
+                # Use scene's primary directly; fallback is the ordered chain.
+                from uncommon_route.router.types import (
+                    FallbackOption,
+                    RoutingDecision,
+                    AnswerDepth as _AD,
+                )
+                from uncommon_route.router.structural import estimate_output_budget as _eob
+                _scene_pool = _active_scene.model_pool()
+                _scene_budget = _eob(prompt, "COMPLEX")
+                _scene_cost = _estimate_cost(
+                    _active_scene.primary,
+                    estimate_tokens(prompt),
+                    min(max_tokens, _scene_budget),
+                )
+                _scene_baseline = _estimate_baseline_cost(
+                    estimate_tokens(prompt),
+                    min(max_tokens, _scene_budget),
+                )
+                decision = RoutingDecision(
+                    model=_active_scene.primary,
+                    tier=Tier.COMPLEX,
+                    mode=routing_mode or RoutingMode.AUTO,
+                    confidence=1.0,
+                    method=f"scene:{_active_scene.name}:hard-pin",
+                    reasoning=f"scene={_active_scene.name} hard-pin → {_active_scene.primary}",
+                    cost_estimate=_scene_cost,
+                    baseline_cost=_scene_baseline,
+                    savings=max(0.0, (_scene_baseline - _scene_cost) / _scene_baseline) if _scene_baseline > 0 else 0.0,
+                    complexity=1.0,
+                    fallback_chain=[
+                        FallbackOption(model=m, cost_estimate=0.0, suggested_output_budget=_scene_budget)
+                        for m in _scene_pool[1:]
+                    ],
+                )
+            elif _active_scene:
+                # Soft scene: constrain candidate pool to scene's models,
+                # optionally override complexity, but let select_from_pool
+                # do multi-dimensional scoring (latency/reliability/feedback/bandit).
+                _scene_constraints = _active_scene.as_routing_constraints()
+                _scene_weights = _active_scene.as_selection_weights()
+                decision = route(
+                    prompt,
+                    system_prompt,
+                    max_tokens,
+                    config=_routing_config,
+                    routing_mode=routing_mode or RoutingMode.AUTO,
+                    request_requirements=requirements,
+                    workload_hints=hints,
+                    user_keyed_models=user_keyed,
+                    model_experience=_model_experience,
+                    pricing=_get_pricing(),
+                    available_models=_active_scene.model_pool(),
+                    model_capabilities=_routing_config.model_capabilities,
+                    routing_constraints=_scene_constraints,
+                    tier_floor=_active_scene.tier_floor,
+                    tier_cap=_active_scene.tier_cap,
+                )
+            else:
+                # Normal routing (no scene active)
+                decision = route(
+                    prompt,
+                    system_prompt,
+                    max_tokens,
+                    config=_routing_config,
+                    routing_mode=routing_mode or RoutingMode.AUTO,
+                    request_requirements=requirements,
+                    workload_hints=hints,
+                    user_keyed_models=user_keyed,
+                    model_experience=_model_experience,
+                    pricing=_get_pricing(),
+                    available_models=_mapper.available_models if _mapper.discovered else None,
+                    model_capabilities=_routing_config.model_capabilities,
+                )
+
             selected_model = decision.model
             tier_value = decision.tier.value
             decision_tier = tier_value
@@ -2647,6 +2808,8 @@ def create_app(
         Route("/v1/stats", handle_stats, methods=["GET", "POST"]),
         Route("/v1/selector", handle_selector, methods=["GET", "POST"]),
         Route("/v1/routing-config", handle_routing_config, methods=["GET", "POST"]),
+        Route("/v1/scenes", handle_scenes, methods=["GET", "POST"]),
+        Route("/v1/scenes/{name:str}", handle_scene_detail, methods=["GET"]),
         Route("/v1/artifacts", handle_artifacts, methods=["GET"]),
         Route("/v1/artifacts/{artifact_id:str}", handle_artifact, methods=["GET"]),
         Route("/v1/feedback", handle_feedback, methods=["GET", "POST"]),

--- a/uncommon_route/proxy.py
+++ b/uncommon_route/proxy.py
@@ -78,7 +78,7 @@ from uncommon_route.providers import (
 )
 from uncommon_route.model_map import ModelMapper
 from uncommon_route.routing_config_store import RoutingConfigStore
-from uncommon_route.scene_store import SceneConfig, SceneStore
+from uncommon_route.scene_store import SceneConfig, SceneStore, _serialize_scene
 from uncommon_route.connections_store import ConnectionsStore, mask_api_key, resolve_primary_connection
 from uncommon_route.anthropic_compat import (
     anthropic_to_openai_request,
@@ -1629,16 +1629,29 @@ def create_app(
                     fallback = [str(f).strip() for f in fallback_raw if str(f).strip()]
                 else:
                     fallback = []
+                tier_floor_raw = body.get("tier_floor")
+                tier_floor = Tier(str(tier_floor_raw).upper()) if tier_floor_raw else None
+                tier_cap_raw = body.get("tier_cap")
+                tier_cap = Tier(str(tier_cap_raw).upper()) if tier_cap_raw else None
+                allowed_providers_raw = body.get("allowed_providers", [])
+                allowed_providers = (
+                    [str(p).strip() for p in allowed_providers_raw if str(p).strip()]
+                    if isinstance(allowed_providers_raw, list) else []
+                )
+                max_cost_raw = body.get("max_cost_per_request")
+                max_cost = float(max_cost_raw) if max_cost_raw is not None else None
+                if max_cost is not None and max_cost <= 0:
+                    return JSONResponse({"error": "max_cost_per_request must be positive"}, status_code=400)
                 scene = SceneConfig(
                     name=name,
                     primary=primary,
                     fallback=fallback,
                     hard_pin=bool(body.get("hard_pin", False)),
                     description=str(body.get("description", "")),
-                    complexity_override=body.get("complexity_override"),
-                    allowed_providers=body.get("allowed_providers", []),
-                    selection_weights_override=body.get("selection_weights_override"),
-                    max_cost_per_request=body.get("max_cost_per_request"),
+                    tier_floor=tier_floor,
+                    tier_cap=tier_cap,
+                    allowed_providers=allowed_providers,
+                    max_cost_per_request=max_cost,
                 )
                 stored = _scene_store.add(scene)
                 return JSONResponse({"ok": True, "scene": _serialize_scene_response(stored)})
@@ -1669,7 +1682,6 @@ def create_app(
         return JSONResponse(_serialize_scene_response(scene))
 
     def _serialize_scene_response(scene: SceneConfig) -> dict:
-        from uncommon_route.scene_store import _serialize_scene
         data = _serialize_scene(scene)
         data["model_pool"] = scene.model_pool()
         return data
@@ -1878,10 +1890,9 @@ def create_app(
                 )
             elif _active_scene:
                 # Soft scene: constrain candidate pool to scene's models,
-                # optionally override complexity, but let select_from_pool
-                # do multi-dimensional scoring (latency/reliability/feedback/bandit).
+                # let select_from_pool do multi-dimensional scoring
+                # (latency/reliability/feedback/bandit).
                 _scene_constraints = _active_scene.as_routing_constraints()
-                _scene_weights = _active_scene.as_selection_weights()
                 decision = route(
                     prompt,
                     system_prompt,
@@ -1932,7 +1943,8 @@ def create_app(
             baseline_cost = decision.baseline_cost
             confidence = decision.confidence
             savings = decision.savings
-            route_method = "pool"
+            if not _active_scene:
+                route_method = "pool"
             mode_value = decision.mode.value
 
             body["model"] = selected_model

--- a/uncommon_route/proxy.py
+++ b/uncommon_route/proxy.py
@@ -106,6 +106,7 @@ from uncommon_route.providers import (
 )
 from uncommon_route.model_map import ModelMapper
 from uncommon_route.routing_config_store import RoutingConfigStore
+from uncommon_route.scene_store import SceneConfig, SceneStore, _serialize_scene
 from uncommon_route.connections_store import ConnectionsStore, mask_api_key, resolve_primary_connection
 from uncommon_route.anthropic_compat import (
     anthropic_to_openai_request,
@@ -2853,6 +2854,7 @@ def create_app(
     _semantic = semantic_compressor
     _routing_store = routing_config_store or RoutingConfigStore()
     _routing_config = _routing_store.config()
+    _scene_store = SceneStore()
     _responses_history: dict[str, list[dict[str, Any]]] = {}
     forced_messages_mode_raw = str(os.environ.get("UNCOMMON_ROUTE_FORCE_MESSAGES_DEFAULT_MODE", "")).strip()
     forced_messages_upstream_model = str(
@@ -3669,6 +3671,86 @@ def create_app(
         _refresh_active_pricing()
         return JSONResponse(payload)
 
+    async def handle_scenes(request: Request) -> JSONResponse:
+        """GET /v1/scenes — list all scenes.  POST /v1/scenes — add/remove/import."""
+        if request.method == "GET":
+            return JSONResponse(_scene_store.export())
+
+        denied = _admin_auth_failure(request)
+        if denied is not None:
+            return denied
+        body = await request.json()
+        action = str(body.get("action", "")).strip().lower()
+        try:
+            if action == "add":
+                name = str(body.get("name", "")).strip()
+                primary = str(body.get("primary", "")).strip()
+                if not name or not primary:
+                    return JSONResponse({"error": "name and primary are required"}, status_code=400)
+                fallback_raw = body.get("fallback", [])
+                if isinstance(fallback_raw, str):
+                    fallback = [p.strip() for p in fallback_raw.split(",") if p.strip()]
+                elif isinstance(fallback_raw, list):
+                    fallback = [str(f).strip() for f in fallback_raw if str(f).strip()]
+                else:
+                    fallback = []
+                tier_floor_raw = body.get("tier_floor")
+                tier_floor = Tier(str(tier_floor_raw).upper()) if tier_floor_raw else None
+                tier_cap_raw = body.get("tier_cap")
+                tier_cap = Tier(str(tier_cap_raw).upper()) if tier_cap_raw else None
+                allowed_providers_raw = body.get("allowed_providers", [])
+                allowed_providers = (
+                    [str(p).strip() for p in allowed_providers_raw if str(p).strip()]
+                    if isinstance(allowed_providers_raw, list) else []
+                )
+                max_cost_raw = body.get("max_cost_per_request")
+                max_cost = float(max_cost_raw) if max_cost_raw is not None else None
+                if max_cost is not None and max_cost <= 0:
+                    return JSONResponse({"error": "max_cost_per_request must be positive"}, status_code=400)
+                scene = SceneConfig(
+                    name=name,
+                    primary=primary,
+                    fallback=fallback,
+                    hard_pin=bool(body.get("hard_pin", False)),
+                    description=str(body.get("description", "")),
+                    tier_floor=tier_floor,
+                    tier_cap=tier_cap,
+                    allowed_providers=allowed_providers,
+                    max_cost_per_request=max_cost,
+                )
+                stored = _scene_store.add(scene)
+                return JSONResponse({"ok": True, "scene": _serialize_scene_response(stored)})
+            elif action == "remove":
+                name = str(body.get("name", "")).strip()
+                if not name:
+                    return JSONResponse({"error": "name is required"}, status_code=400)
+                removed = _scene_store.remove(name)
+                return JSONResponse({"ok": removed, "name": name})
+            elif action == "import":
+                data = body.get("data", {})
+                count = _scene_store.import_scenes(data)
+                return JSONResponse({"ok": True, "imported": count})
+            else:
+                return JSONResponse(
+                    {"error": "Invalid action", "allowed": ["add", "remove", "import"]},
+                    status_code=400,
+                )
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+
+    async def handle_scene_detail(request: Request) -> JSONResponse:
+        """GET /v1/scenes/<name> — get one scene."""
+        name = request.path_params["name"]
+        scene = _scene_store.get(name)
+        if scene is None:
+            return JSONResponse({"error": f"Scene '{name}' not found"}, status_code=404)
+        return JSONResponse(_serialize_scene_response(scene))
+
+    def _serialize_scene_response(scene: SceneConfig) -> dict:
+        data = _serialize_scene(scene)
+        data["model_pool"] = scene.model_pool()
+        return data
+
     async def handle_artifacts(request: Request) -> JSONResponse:
         limit = int(request.query_params.get("limit", "50"))
         return JSONResponse({
@@ -4064,6 +4146,41 @@ def create_app(
                     retrial_previous.model,
                 )
 
+        # ── Scene resolution ───────────────────────────────────────────
+        # Trigger precedence:
+        #   1. x-uncommon-route-scene header
+        #   2. Virtual model ID: uncommon-route/scene/<name>
+        #   3. (Future: OpenClaw session → scene mapping via plugin)
+        _scene_name: str | None = None
+        _active_scene: SceneConfig | None = None
+
+        # Check header first (highest priority)
+        _scene_header = request.headers.get("x-uncommon-route-scene", "").strip()
+        if _scene_header:
+            _scene_name = _scene_header
+
+        # Check virtual model ID: uncommon-route/scene/<name>
+        if not _scene_name and model.startswith("uncommon-route/scene/"):
+            _scene_name = model[len("uncommon-route/scene/"):].strip()
+            # Treat scene requests as virtual (need routing)
+            if not is_virtual:
+                is_virtual = True
+                routing_mode = RoutingMode.AUTO
+                mode_value = routing_mode.value
+
+        if _scene_name:
+            _active_scene = _scene_store.resolve(_scene_name)
+            if _active_scene:
+                if not is_virtual:
+                    is_virtual = True
+                    routing_mode = RoutingMode.AUTO
+                mode_value = routing_mode.value if routing_mode else ""
+                logger.info(
+                    "Scene '%s' active: primary=%s hard_pin=%s",
+                    _active_scene.name, _active_scene.primary, _active_scene.hard_pin,
+                )
+                route_method = f"scene:{_active_scene.name}"
+
         if is_virtual:
             _set_header(debug_headers, "x-uncommon-route-mode", mode_value)
             if prompt.startswith("/debug"):
@@ -4100,6 +4217,10 @@ def create_app(
                 route_available_models = _circuit_breaker.filter_available(
                     _mapper.routable_models if _mapper.discovered else list(DEFAULT_MODEL_PRICING.keys())
                 )
+                if _active_scene and not _active_scene.hard_pin:
+                    scene_pool = _active_scene.model_pool()
+                    available_scene_models = [m for m in scene_pool if m in route_available_models]
+                    route_available_models = available_scene_models or scene_pool
                 route_available_models, transport_pool_note = _filter_transport_compatible_models(
                     available_models=route_available_models,
                     api_format=api_format,
@@ -4124,22 +4245,87 @@ def create_app(
                 )
                 if thinking_lock_note:
                     route_pool_notes.append(thinking_lock_note)
-                decision = route(
-                    prompt,
-                    system_prompt,
-                    max_tokens,
-                    config=_routing_config,
-                    routing_mode=routing_mode or RoutingMode.AUTO,
-                    routing_features=routing_features,
-                    user_keyed_models=user_keyed,
-                    model_experience=_model_experience,
-                    route_confidence_calibrator=_route_confidence,
-                    context_features=ctx_features,
-                    pricing=_get_pricing(),
-                    available_models=route_available_models or None,
-                    model_capabilities=_routing_config.model_capabilities,
-                    messages=body.get("messages"),
-                )
+
+                if _active_scene and _active_scene.hard_pin:
+                    from uncommon_route.router.types import (
+                        AnswerDepth,
+                        FallbackOption,
+                        RoutingDecision,
+                    )
+
+                    scene_pool = _active_scene.model_pool()
+                    scene_tier = _active_scene.tier_floor or Tier.COMPLEX
+                    scene_budget = estimate_output_budget(prompt, scene_tier.value)
+                    scene_output_budget = min(max_tokens, scene_budget)
+                    input_token_estimate = estimate_tokens(prompt)
+                    scene_cost = _estimate_cost(
+                        _active_scene.primary,
+                        input_token_estimate,
+                        scene_output_budget,
+                    )
+                    scene_baseline = _estimate_baseline_cost(
+                        input_token_estimate,
+                        scene_output_budget,
+                    )
+                    scene_lane = request_capability_lane(routing_features)
+                    scene_quality = model_served_quality(
+                        _active_scene.primary,
+                        scene_lane,
+                        _routing_config.model_capabilities.get(_active_scene.primary),
+                    )
+                    decision = RoutingDecision(
+                        model=_active_scene.primary,
+                        tier=scene_tier,
+                        capability_lane=scene_lane,
+                        served_quality=scene_quality,
+                        served_quality_target=scene_quality,
+                        served_quality_floor=routing_features.continuity_quality_floor,
+                        continuity_quality_floor=routing_features.continuity_quality_floor,
+                        mode=routing_mode or RoutingMode.AUTO,
+                        confidence=1.0,
+                        method=f"scene:{_active_scene.name}:hard-pin",
+                        reasoning=f"scene={_active_scene.name} hard-pin -> {_active_scene.primary}",
+                        cost_estimate=scene_cost,
+                        baseline_cost=scene_baseline,
+                        savings=(
+                            max(0.0, (scene_baseline - scene_cost) / scene_baseline)
+                            if scene_baseline > 0
+                            else 0.0
+                        ),
+                        raw_confidence=1.0,
+                        confidence_source="scene",
+                        complexity=1.0,
+                        constraints=_active_scene.as_routing_constraints(),
+                        workload_hints=hints,
+                        routing_features=routing_features,
+                        answer_depth=AnswerDepth.STANDARD,
+                        suggested_output_budget=scene_output_budget,
+                        fallback_chain=[
+                            FallbackOption(model=m, cost_estimate=0.0, suggested_output_budget=scene_output_budget)
+                            for m in scene_pool[1:]
+                        ],
+                    )
+                else:
+                    scene_constraints = _active_scene.as_routing_constraints() if _active_scene else None
+                    decision = route(
+                        prompt,
+                        system_prompt,
+                        max_tokens,
+                        config=_routing_config,
+                        routing_mode=routing_mode or RoutingMode.AUTO,
+                        routing_features=routing_features,
+                        routing_constraints=scene_constraints,
+                        user_keyed_models=user_keyed,
+                        model_experience=_model_experience,
+                        route_confidence_calibrator=_route_confidence,
+                        context_features=ctx_features,
+                        pricing=_get_pricing(),
+                        available_models=route_available_models or None,
+                        model_capabilities=_routing_config.model_capabilities,
+                        messages=body.get("messages"),
+                        tier_floor=_active_scene.tier_floor if _active_scene else None,
+                        tier_cap=_active_scene.tier_cap if _active_scene else None,
+                    )
             except RoutingInfeasibleError as exc:
                 route_latency_us = (time.perf_counter_ns() - route_start) / 1000
                 route_reasoning = exc.infeasibility.message
@@ -4245,13 +4431,14 @@ def create_app(
                 )
             tier_value = decision.tier.value
             decision_tier = tier_value
+            route_method = decision.method
             get_bus().publish({
                 "type": "request_routed",
                 "request_id": request_id,
                 "turn_id": turn_id,
                 "tier": tier_value,
                 "model": selected_model,
-                "method": "pool",
+                "method": route_method,
                 "transport": transport_decision.selected_transport,
                 "prompt_preview": prompt_preview,
             })
@@ -4280,7 +4467,6 @@ def create_app(
             baseline_cost = decision.baseline_cost
             confidence = decision.confidence
             savings = decision.savings
-            route_method = "pool"
             mode_value = decision.mode.value
             raw_confidence = decision.raw_confidence
             confidence_source = decision.confidence_source
@@ -4786,6 +4972,7 @@ def create_app(
             _set_header(debug_headers, "x-uncommon-route-model", selected_model)
             _set_header(debug_headers, "x-uncommon-route-tier", tier_value)
             _set_header(debug_headers, "x-uncommon-route-decision-tier", decision_tier or tier_value)
+            _set_header(debug_headers, "x-uncommon-route-method", route_method)
             if served_quality_value:
                 _set_header(debug_headers, "x-uncommon-route-served-quality", served_quality_value)
             if capability_lane_value:
@@ -4822,6 +5009,7 @@ def create_app(
             if not is_virtual:
                 return
             _set_header(debug_headers, "x-uncommon-route-model", selected_model)
+            _set_header(debug_headers, "x-uncommon-route-method", route_method)
             if served_quality_value:
                 _set_header(debug_headers, "x-uncommon-route-served-quality", served_quality_value)
             if capability_lane_value:
@@ -5869,6 +6057,8 @@ def create_app(
         Route("/v1/stats", handle_stats, methods=["GET", "POST"]),
         Route("/v1/selector", handle_selector, methods=["GET", "POST"]),
         Route("/v1/routing-config", handle_routing_config, methods=["GET", "POST"]),
+        Route("/v1/scenes", handle_scenes, methods=["GET", "POST"]),
+        Route("/v1/scenes/{name:str}", handle_scene_detail, methods=["GET"]),
         Route("/v1/artifacts", handle_artifacts, methods=["GET"]),
         Route("/v1/artifacts/{artifact_id:str}", handle_artifact, methods=["GET"]),
         Route("/v1/feedback", handle_feedback, methods=["GET", "POST"]),

--- a/uncommon_route/scene_store.py
+++ b/uncommon_route/scene_store.py
@@ -1,0 +1,300 @@
+"""Named scene routing — persistent, user-defined routing profiles.
+
+A *scene* is a named routing preset that overrides (or constrains) the
+normal classifier → selector pipeline.  Scenes let users declare
+domain-specific routing policies like "intimate" (always opus, hard-pin)
+or "construction_crew" (cheap models only, adaptive selection).
+
+Two behaviours depending on ``hard_pin``:
+
+* **hard_pin=True** — bypass classifier *and* selector; use
+  ``primary`` directly with ``fallback`` as the ordered chain.
+* **hard_pin=False** — bypass the classifier (use ``complexity_override``
+  or default 0.5), but let ``select_from_pool`` score within the scene's
+  model list.  This preserves latency/reliability/feedback/bandit scoring.
+
+Trigger precedence (checked in proxy):
+
+1. ``x-uncommon-route-scene: <name>`` request header
+2. Virtual model ID ``uncommon-route/scene/<name>``
+3. OpenClaw session → scene mapping (injected as header by plugin)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from uncommon_route.paths import data_dir
+from uncommon_route.router.types import (
+    RoutingConstraints,
+    SelectionWeights,
+    Tier,
+)
+
+logger = logging.getLogger("uncommon-route.scene")
+
+_DATA_DIR = data_dir()
+_SCENES_FILE = _DATA_DIR / "scenes.json"
+
+
+@dataclass
+class SceneConfig:
+    """A named routing scene."""
+
+    name: str
+    primary: str
+    fallback: list[str] = field(default_factory=list)
+    hard_pin: bool = False
+    description: str = ""
+
+    # When hard_pin=False, this value replaces the classifier output.
+    # None means "run the classifier normally" (scene only constrains
+    # the candidate pool, not the complexity signal).
+    complexity_override: float | None = None
+
+    # Optional tier floor/cap — lets a scene say "at least MEDIUM".
+    tier_floor: Tier | None = None
+    tier_cap: Tier | None = None
+
+    # Provider-level constraint (e.g. only allow anthropic/).
+    allowed_providers: list[str] = field(default_factory=list)
+
+    # Per-scene selection weight overrides (None = use global defaults).
+    selection_weights_override: dict[str, float] | None = None
+
+    # Per-scene spend limit ($/request).  None = no limit.
+    max_cost_per_request: float | None = None
+
+    def model_pool(self) -> list[str]:
+        """Return ordered candidate list: [primary, *fallback]."""
+        seen: set[str] = set()
+        pool: list[str] = []
+        for model in [self.primary, *self.fallback]:
+            normalized = model.strip()
+            if normalized and normalized not in seen:
+                pool.append(normalized)
+                seen.add(normalized)
+        return pool
+
+    def as_routing_constraints(self) -> RoutingConstraints:
+        """Build a RoutingConstraints from scene settings."""
+        return RoutingConstraints(
+            allowed_models=tuple(self.model_pool()),
+            allowed_providers=tuple(self.allowed_providers),
+            max_cost=self.max_cost_per_request,
+        )
+
+    def as_selection_weights(self) -> SelectionWeights | None:
+        """Build SelectionWeights if overrides are defined."""
+        if not self.selection_weights_override:
+            return None
+        defaults = SelectionWeights()
+        kwargs: dict[str, float] = {}
+        for fld in defaults.__dataclass_fields__:
+            kwargs[fld] = self.selection_weights_override.get(
+                fld, getattr(defaults, fld)
+            )
+        return SelectionWeights(**kwargs)
+
+
+def _serialize_scene(scene: SceneConfig) -> dict[str, Any]:
+    """Convert SceneConfig → JSON-safe dict."""
+    data = asdict(scene)
+    # Convert Tier enums to strings
+    if data.get("tier_floor") is not None:
+        data["tier_floor"] = data["tier_floor"].value if isinstance(data["tier_floor"], Tier) else str(data["tier_floor"])
+    else:
+        data.pop("tier_floor", None)
+    if data.get("tier_cap") is not None:
+        data["tier_cap"] = data["tier_cap"].value if isinstance(data["tier_cap"], Tier) else str(data["tier_cap"])
+    else:
+        data.pop("tier_cap", None)
+    # Strip None/empty optionals for cleaner JSON
+    if not data.get("allowed_providers"):
+        data.pop("allowed_providers", None)
+    if data.get("selection_weights_override") is None:
+        data.pop("selection_weights_override", None)
+    if data.get("max_cost_per_request") is None:
+        data.pop("max_cost_per_request", None)
+    if data.get("complexity_override") is None:
+        data.pop("complexity_override", None)
+    return data
+
+
+def _deserialize_scene(data: dict[str, Any]) -> SceneConfig | None:
+    """Parse a JSON dict → SceneConfig.  Returns None on invalid data."""
+    try:
+        name = str(data.get("name", "")).strip().lower()
+        primary = str(data.get("primary", "")).strip()
+        if not name or not primary:
+            return None
+
+        fallback_raw = data.get("fallback", [])
+        fallback = (
+            [str(f).strip() for f in fallback_raw]
+            if isinstance(fallback_raw, list)
+            else [str(fallback_raw).strip()]
+        )
+
+        tier_floor = None
+        if "tier_floor" in data and data["tier_floor"]:
+            try:
+                tier_floor = Tier(str(data["tier_floor"]).upper())
+            except ValueError:
+                pass
+
+        tier_cap = None
+        if "tier_cap" in data and data["tier_cap"]:
+            try:
+                tier_cap = Tier(str(data["tier_cap"]).upper())
+            except ValueError:
+                pass
+
+        allowed_providers = data.get("allowed_providers", [])
+        if not isinstance(allowed_providers, list):
+            allowed_providers = []
+
+        return SceneConfig(
+            name=name,
+            primary=primary,
+            fallback=[f for f in fallback if f],
+            hard_pin=bool(data.get("hard_pin", False)),
+            description=str(data.get("description", "")),
+            complexity_override=data.get("complexity_override"),
+            tier_floor=tier_floor,
+            tier_cap=tier_cap,
+            allowed_providers=[str(p).strip() for p in allowed_providers if str(p).strip()],
+            selection_weights_override=data.get("selection_weights_override"),
+            max_cost_per_request=data.get("max_cost_per_request"),
+        )
+    except Exception:
+        logger.warning("Failed to deserialize scene: %s", data, exc_info=True)
+        return None
+
+
+class SceneStore:
+    """CRUD store for named scenes, backed by a JSON file."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self._path = path or _SCENES_FILE
+        self._scenes: dict[str, SceneConfig] = {}
+        self._load()
+
+    def _load(self) -> None:
+        """Load scenes from disk.  Silently ignores corrupt files."""
+        self._scenes = {}
+        try:
+            if self._path.exists():
+                raw = json.loads(self._path.read_text())
+                if isinstance(raw, dict):
+                    scenes_data = raw.get("scenes", {})
+                    if isinstance(scenes_data, dict):
+                        for _key, scene_data in scenes_data.items():
+                            scene = _deserialize_scene(scene_data)
+                            if scene:
+                                self._scenes[scene.name] = scene
+        except Exception:
+            logger.warning("Failed to load scenes from %s", self._path, exc_info=True)
+
+    def _save(self) -> None:
+        """Persist scenes to disk."""
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            data = {
+                "version": "1.0",
+                "scenes": {
+                    name: _serialize_scene(scene)
+                    for name, scene in sorted(self._scenes.items())
+                },
+            }
+            self._path.write_text(json.dumps(data, indent=2, sort_keys=True))
+            self._path.chmod(0o600)
+        except Exception:
+            logger.error("Failed to save scenes to %s", self._path, exc_info=True)
+
+    def get(self, name: str) -> SceneConfig | None:
+        """Look up a scene by name (case-insensitive)."""
+        return self._scenes.get(name.strip().lower())
+
+    def list(self) -> list[SceneConfig]:
+        """Return all scenes, sorted by name."""
+        return sorted(self._scenes.values(), key=lambda s: s.name)
+
+    def add(self, scene: SceneConfig) -> SceneConfig:
+        """Add or update a scene.  Returns the stored scene."""
+        normalized = SceneConfig(
+            name=scene.name.strip().lower(),
+            primary=scene.primary.strip(),
+            fallback=[f.strip() for f in scene.fallback if f.strip()],
+            hard_pin=scene.hard_pin,
+            description=scene.description,
+            complexity_override=scene.complexity_override,
+            tier_floor=scene.tier_floor,
+            tier_cap=scene.tier_cap,
+            allowed_providers=scene.allowed_providers,
+            selection_weights_override=scene.selection_weights_override,
+            max_cost_per_request=scene.max_cost_per_request,
+        )
+        # Deduplicate fallback against primary
+        normalized = SceneConfig(
+            **{
+                **asdict(normalized),
+                "fallback": [
+                    f for f in normalized.fallback if f != normalized.primary
+                ],
+                "tier_floor": normalized.tier_floor,
+                "tier_cap": normalized.tier_cap,
+            }
+        )
+        self._scenes[normalized.name] = normalized
+        self._save()
+        return normalized
+
+    def remove(self, name: str) -> bool:
+        """Remove a scene.  Returns True if it existed."""
+        key = name.strip().lower()
+        if key in self._scenes:
+            del self._scenes[key]
+            self._save()
+            return True
+        return False
+
+    def resolve(self, name: str) -> SceneConfig | None:
+        """Resolve a scene name, with graceful degradation.
+
+        Returns None if the scene doesn't exist (caller falls back to
+        normal routing).
+        """
+        scene = self.get(name)
+        if scene is None:
+            logger.debug("Scene '%s' not found, falling back to normal routing", name)
+        return scene
+
+    def export(self) -> dict[str, Any]:
+        """Export all scenes as a JSON-serializable dict."""
+        return {
+            "version": "1.0",
+            "scenes": {
+                name: _serialize_scene(scene)
+                for name, scene in sorted(self._scenes.items())
+            },
+        }
+
+    def import_scenes(self, data: dict[str, Any]) -> int:
+        """Import scenes from a dict (merge, not replace).  Returns count added."""
+        count = 0
+        scenes_data = data.get("scenes", {})
+        if isinstance(scenes_data, dict):
+            for _key, scene_data in scenes_data.items():
+                scene = _deserialize_scene(scene_data)
+                if scene:
+                    self._scenes[scene.name] = scene
+                    count += 1
+        if count:
+            self._save()
+        return count

--- a/uncommon_route/scene_store.py
+++ b/uncommon_route/scene_store.py
@@ -9,9 +9,10 @@ Two behaviours depending on ``hard_pin``:
 
 * **hard_pin=True** — bypass classifier *and* selector; use
   ``primary`` directly with ``fallback`` as the ordered chain.
-* **hard_pin=False** — bypass the classifier (use ``complexity_override``
-  or default 0.5), but let ``select_from_pool`` score within the scene's
-  model list.  This preserves latency/reliability/feedback/bandit scoring.
+* **hard_pin=False** — constrain candidate pool to the scene's model
+  list, optionally apply tier_floor/tier_cap, but let the full
+  classifier → selector pipeline score within that pool.
+  This preserves latency/reliability/feedback/bandit scoring.
 
 Trigger precedence (checked in proxy):
 
@@ -25,14 +26,13 @@ from __future__ import annotations
 import json
 import logging
 import os
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
 from uncommon_route.paths import data_dir
 from uncommon_route.router.types import (
     RoutingConstraints,
-    SelectionWeights,
     Tier,
 )
 
@@ -52,20 +52,12 @@ class SceneConfig:
     hard_pin: bool = False
     description: str = ""
 
-    # When hard_pin=False, this value replaces the classifier output.
-    # None means "run the classifier normally" (scene only constrains
-    # the candidate pool, not the complexity signal).
-    complexity_override: float | None = None
-
     # Optional tier floor/cap — lets a scene say "at least MEDIUM".
     tier_floor: Tier | None = None
     tier_cap: Tier | None = None
 
     # Provider-level constraint (e.g. only allow anthropic/).
     allowed_providers: list[str] = field(default_factory=list)
-
-    # Per-scene selection weight overrides (None = use global defaults).
-    selection_weights_override: dict[str, float] | None = None
 
     # Per-scene spend limit ($/request).  None = no limit.
     max_cost_per_request: float | None = None
@@ -89,17 +81,9 @@ class SceneConfig:
             max_cost=self.max_cost_per_request,
         )
 
-    def as_selection_weights(self) -> SelectionWeights | None:
-        """Build SelectionWeights if overrides are defined."""
-        if not self.selection_weights_override:
-            return None
-        defaults = SelectionWeights()
-        kwargs: dict[str, float] = {}
-        for fld in defaults.__dataclass_fields__:
-            kwargs[fld] = self.selection_weights_override.get(
-                fld, getattr(defaults, fld)
-            )
-        return SelectionWeights(**kwargs)
+    def as_selection_weights(self) -> None:
+        """Reserved for future use when route() supports injected weights."""
+        return None
 
 
 def _serialize_scene(scene: SceneConfig) -> dict[str, Any]:
@@ -117,12 +101,8 @@ def _serialize_scene(scene: SceneConfig) -> dict[str, Any]:
     # Strip None/empty optionals for cleaner JSON
     if not data.get("allowed_providers"):
         data.pop("allowed_providers", None)
-    if data.get("selection_weights_override") is None:
-        data.pop("selection_weights_override", None)
     if data.get("max_cost_per_request") is None:
         data.pop("max_cost_per_request", None)
-    if data.get("complexity_override") is None:
-        data.pop("complexity_override", None)
     return data
 
 
@@ -165,11 +145,9 @@ def _deserialize_scene(data: dict[str, Any]) -> SceneConfig | None:
             fallback=[f for f in fallback if f],
             hard_pin=bool(data.get("hard_pin", False)),
             description=str(data.get("description", "")),
-            complexity_override=data.get("complexity_override"),
             tier_floor=tier_floor,
             tier_cap=tier_cap,
             allowed_providers=[str(p).strip() for p in allowed_providers if str(p).strip()],
-            selection_weights_override=data.get("selection_weights_override"),
             max_cost_per_request=data.get("max_cost_per_request"),
         )
     except Exception:
@@ -233,23 +211,15 @@ class SceneStore:
             fallback=[f.strip() for f in scene.fallback if f.strip()],
             hard_pin=scene.hard_pin,
             description=scene.description,
-            complexity_override=scene.complexity_override,
             tier_floor=scene.tier_floor,
             tier_cap=scene.tier_cap,
             allowed_providers=scene.allowed_providers,
-            selection_weights_override=scene.selection_weights_override,
             max_cost_per_request=scene.max_cost_per_request,
         )
         # Deduplicate fallback against primary
-        normalized = SceneConfig(
-            **{
-                **asdict(normalized),
-                "fallback": [
-                    f for f in normalized.fallback if f != normalized.primary
-                ],
-                "tier_floor": normalized.tier_floor,
-                "tier_cap": normalized.tier_cap,
-            }
+        normalized = replace(
+            normalized,
+            fallback=[f for f in normalized.fallback if f != normalized.primary],
         )
         self._scenes[normalized.name] = normalized
         self._save()

--- a/uncommon_route/scene_store.py
+++ b/uncommon_route/scene_store.py
@@ -1,0 +1,269 @@
+"""Named scene routing — persistent, user-defined routing profiles.
+
+A *scene* is a named routing preset that overrides (or constrains) the
+normal classifier → selector pipeline.  Scenes let users declare
+domain-specific routing policies like "intimate" (always opus, hard-pin)
+or "construction_crew" (cheap models only, adaptive selection).
+
+Two behaviours depending on ``hard_pin``:
+
+* **hard_pin=True** — bypass classifier *and* selector; use
+  ``primary`` directly with ``fallback`` as the ordered chain.
+* **hard_pin=False** — constrain candidate pool to the scene's model
+  list, optionally apply tier_floor/tier_cap, but let the full
+  classifier → selector pipeline score within that pool.
+  This preserves latency/reliability/feedback/bandit scoring.
+
+Trigger precedence (checked in proxy):
+
+1. ``x-uncommon-route-scene: <name>`` request header
+2. Virtual model ID ``uncommon-route/scene/<name>``
+3. OpenClaw session → scene mapping (injected as header by plugin)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass, field, replace
+from pathlib import Path
+from typing import Any
+
+from uncommon_route.paths import data_dir
+from uncommon_route.router.types import (
+    RoutingConstraints,
+    Tier,
+)
+
+logger = logging.getLogger("uncommon-route.scene")
+
+_DATA_DIR = data_dir()
+_SCENES_FILE = _DATA_DIR / "scenes.json"
+
+
+@dataclass
+class SceneConfig:
+    """A named routing scene."""
+
+    name: str
+    primary: str
+    fallback: list[str] = field(default_factory=list)
+    hard_pin: bool = False
+    description: str = ""
+
+    # Optional tier floor/cap — lets a scene say "at least MEDIUM".
+    tier_floor: Tier | None = None
+    tier_cap: Tier | None = None
+
+    # Provider-level constraint (e.g. only allow anthropic/).
+    allowed_providers: list[str] = field(default_factory=list)
+
+    # Per-scene spend limit ($/request).  None = no limit.
+    max_cost_per_request: float | None = None
+
+    def model_pool(self) -> list[str]:
+        """Return ordered candidate list: [primary, *fallback]."""
+        seen: set[str] = set()
+        pool: list[str] = []
+        for model in [self.primary, *self.fallback]:
+            normalized = model.strip()
+            if normalized and normalized not in seen:
+                pool.append(normalized)
+                seen.add(normalized)
+        return pool
+
+    def as_routing_constraints(self) -> RoutingConstraints:
+        """Build a RoutingConstraints from scene settings."""
+        return RoutingConstraints(
+            allowed_models=tuple(self.model_pool()),
+            allowed_providers=tuple(self.allowed_providers),
+            max_cost=self.max_cost_per_request,
+        )
+
+    def as_selection_weights(self) -> None:
+        """Reserved for future use when route() supports injected weights."""
+        return None
+
+
+def _serialize_scene(scene: SceneConfig) -> dict[str, Any]:
+    """Convert SceneConfig → JSON-safe dict."""
+    data = asdict(scene)
+    # Convert Tier enums to strings
+    if data.get("tier_floor") is not None:
+        data["tier_floor"] = data["tier_floor"].value if isinstance(data["tier_floor"], Tier) else str(data["tier_floor"])
+    else:
+        data.pop("tier_floor", None)
+    if data.get("tier_cap") is not None:
+        data["tier_cap"] = data["tier_cap"].value if isinstance(data["tier_cap"], Tier) else str(data["tier_cap"])
+    else:
+        data.pop("tier_cap", None)
+    # Strip None/empty optionals for cleaner JSON
+    if not data.get("allowed_providers"):
+        data.pop("allowed_providers", None)
+    if data.get("max_cost_per_request") is None:
+        data.pop("max_cost_per_request", None)
+    return data
+
+
+def _deserialize_scene(data: dict[str, Any]) -> SceneConfig | None:
+    """Parse a JSON dict → SceneConfig.  Returns None on invalid data."""
+    try:
+        name = str(data.get("name", "")).strip().lower()
+        primary = str(data.get("primary", "")).strip()
+        if not name or not primary:
+            return None
+
+        fallback_raw = data.get("fallback", [])
+        fallback = (
+            [str(f).strip() for f in fallback_raw]
+            if isinstance(fallback_raw, list)
+            else [str(fallback_raw).strip()]
+        )
+
+        tier_floor = None
+        if "tier_floor" in data and data["tier_floor"]:
+            try:
+                tier_floor = Tier(str(data["tier_floor"]).upper())
+            except ValueError:
+                pass
+
+        tier_cap = None
+        if "tier_cap" in data and data["tier_cap"]:
+            try:
+                tier_cap = Tier(str(data["tier_cap"]).upper())
+            except ValueError:
+                pass
+
+        allowed_providers = data.get("allowed_providers", [])
+        if not isinstance(allowed_providers, list):
+            allowed_providers = []
+
+        return SceneConfig(
+            name=name,
+            primary=primary,
+            fallback=[f for f in fallback if f],
+            hard_pin=bool(data.get("hard_pin", False)),
+            description=str(data.get("description", "")),
+            tier_floor=tier_floor,
+            tier_cap=tier_cap,
+            allowed_providers=[str(p).strip() for p in allowed_providers if str(p).strip()],
+            max_cost_per_request=data.get("max_cost_per_request"),
+        )
+    except Exception:
+        logger.warning("Failed to deserialize scene: %s", data, exc_info=True)
+        return None
+
+
+class SceneStore:
+    """CRUD store for named scenes, backed by a JSON file."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self._path = path or _SCENES_FILE
+        self._scenes: dict[str, SceneConfig] = {}
+        self._load()
+
+    def _load(self) -> None:
+        """Load scenes from disk.  Silently ignores corrupt files."""
+        self._scenes = {}
+        try:
+            if self._path.exists():
+                raw = json.loads(self._path.read_text())
+                if isinstance(raw, dict):
+                    scenes_data = raw.get("scenes", {})
+                    if isinstance(scenes_data, dict):
+                        for _key, scene_data in scenes_data.items():
+                            scene = _deserialize_scene(scene_data)
+                            if scene:
+                                self._scenes[scene.name] = scene
+        except Exception:
+            logger.warning("Failed to load scenes from %s", self._path, exc_info=True)
+
+    def _save(self) -> None:
+        """Persist scenes to disk."""
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            data = {
+                "version": "1.0",
+                "scenes": {
+                    name: _serialize_scene(scene)
+                    for name, scene in sorted(self._scenes.items())
+                },
+            }
+            self._path.write_text(json.dumps(data, indent=2, sort_keys=True))
+            self._path.chmod(0o600)
+        except Exception:
+            logger.error("Failed to save scenes to %s", self._path, exc_info=True)
+
+    def get(self, name: str) -> SceneConfig | None:
+        """Look up a scene by name (case-insensitive)."""
+        return self._scenes.get(name.strip().lower())
+
+    def list(self) -> list[SceneConfig]:
+        """Return all scenes, sorted by name."""
+        return sorted(self._scenes.values(), key=lambda s: s.name)
+
+    def add(self, scene: SceneConfig) -> SceneConfig:
+        """Add or update a scene.  Returns the stored scene."""
+        normalized = SceneConfig(
+            name=scene.name.strip().lower(),
+            primary=scene.primary.strip(),
+            fallback=[f.strip() for f in scene.fallback if f.strip()],
+            hard_pin=scene.hard_pin,
+            description=scene.description,
+            tier_floor=scene.tier_floor,
+            tier_cap=scene.tier_cap,
+            allowed_providers=scene.allowed_providers,
+            max_cost_per_request=scene.max_cost_per_request,
+        )
+        # Deduplicate fallback against primary
+        normalized = replace(
+            normalized,
+            fallback=[f for f in normalized.fallback if f != normalized.primary],
+        )
+        self._scenes[normalized.name] = normalized
+        self._save()
+        return normalized
+
+    def remove(self, name: str) -> bool:
+        """Remove a scene.  Returns True if it existed."""
+        key = name.strip().lower()
+        if key in self._scenes:
+            del self._scenes[key]
+            self._save()
+            return True
+        return False
+
+    def resolve(self, name: str) -> SceneConfig | None:
+        """Resolve a scene name, with graceful degradation.
+
+        Returns None if the scene doesn't exist (caller falls back to
+        normal routing).
+        """
+        scene = self.get(name)
+        if scene is None:
+            logger.debug("Scene '%s' not found, falling back to normal routing", name)
+        return scene
+
+    def export(self) -> dict[str, Any]:
+        """Export all scenes as a JSON-serializable dict."""
+        return {
+            "version": "1.0",
+            "scenes": {
+                name: _serialize_scene(scene)
+                for name, scene in sorted(self._scenes.items())
+            },
+        }
+
+    def import_scenes(self, data: dict[str, Any]) -> int:
+        """Import scenes from a dict (merge, not replace).  Returns count added."""
+        count = 0
+        scenes_data = data.get("scenes", {})
+        if isinstance(scenes_data, dict):
+            for _key, scene_data in scenes_data.items():
+                scene = _deserialize_scene(scene_data)
+                if scene:
+                    self._scenes[scene.name] = scene
+                    count += 1
+        if count:
+            self._save()
+        return count


### PR DESCRIPTION
## Summary
- Re-submits the closed #3 named scene routing feature on top of current main.
- Adds persistent SceneStore CRUD, `uncommon-route scene` CLI commands, `/v1/scenes` API, scene-triggered routing via `x-uncommon-route-scene`, and virtual model IDs like `uncommon-route/scene/<name>`.
- Resolves stale conflicts against the current routing/proxy architecture and fixes the review bugs from #3: `scene show` no longer reads a removed field, header-triggered scenes force routing for ordinary model IDs, scene methods remain visible, and scene mutation POSTs now use admin auth.

## Validation
- `PYTHONPATH=/tmp/uncommon-route-test-deps:. pytest -q`
- `PYTHONPATH=/tmp/uncommon-route-test-deps:. pytest tests/test_scene_store.py tests/test_usage_modes.py::TestCLI::test_scene_add_and_show tests/test_proxy.py::TestScenesEndpoint -q`
- `ruff check uncommon_route/cli.py uncommon_route/proxy.py uncommon_route/scene_store.py tests/test_scene_store.py tests/test_proxy.py tests/test_usage_modes.py`
- `PYTHONPATH=/tmp/uncommon-route-test-deps:. python -m build`
- `PYTHONPATH=/tmp/uncommon-route-test-deps:. python -m uncommon_route.cli scene --help`