### PR TITLE
Fix session continuity and BYOK routing pool

### DIFF
--- a/tests/test_anthropic_compat.py
+++ b/tests/test_anthropic_compat.py
@@ -1507,7 +1507,7 @@ class TestTransportRouting:
         finally:
             asyncio.run(async_client.aclose())
 
-    def test_virtual_messages_with_thinking_blocks_use_compatible_pool_without_locking_previous_model(
+    def test_virtual_messages_with_thinking_blocks_lock_to_previous_model(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -1627,15 +1627,12 @@ class TestTransportRouting:
             )
 
             assert resp.status_code == 200
-            assert set(routed["available_models"]) == {
-                "minimax/minimax-m2.7",
-                "anthropic/claude-opus-4-5",
-            }
+            assert routed["available_models"] == ["minimax/minimax-m2.7"]
             assert captured["url"] == "https://api.commonstack.ai/v1/messages"
             request_id = resp.headers["x-uncommon-route-request-id"]
             trace = traces.find(request_id)
             assert trace is not None
-            assert "thinking-context=compatible-pool;previous=minimax/minimax-m2.7" in trace["route_reasoning"]
+            assert "thinking-context=locked-to-previous=minimax/minimax-m2.7" in trace["route_reasoning"]
         finally:
             asyncio.run(async_client.aclose())
 
@@ -1725,7 +1722,7 @@ class TestTransportRouting:
         finally:
             asyncio.run(async_client.aclose())
 
-    def test_virtual_messages_with_thinking_blocks_continue_when_previous_model_unavailable(
+    def test_virtual_messages_with_thinking_blocks_fail_closed_when_previous_model_unavailable(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -1841,14 +1838,10 @@ class TestTransportRouting:
                 },
             )
 
-            assert resp.status_code == 200
-            assert routed["available_models"] == ["anthropic/claude-opus-4-5"]
-            assert called["route"] is True
-            assert called["upstream"] is True
-            request_id = resp.headers["x-uncommon-route-request-id"]
-            trace = traces.find(request_id)
-            assert trace is not None
-            assert "thinking-context=compatible-pool;previous-unavailable=minimax/minimax-m2.7" in trace["route_reasoning"]
+            assert resp.status_code == 400
+            assert called["route"] is False
+            assert called["upstream"] is False
+            assert "signed thinking context" in resp.text
         finally:
             asyncio.run(async_client.aclose())
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -46,6 +46,18 @@ class TestProviderConfig:
         cfg = add_provider("openai", "sk-openai", base_url="https://my-proxy.com/v1")
         assert cfg.providers["openai"].base_url == "https://my-proxy.com/v1"
 
+    def test_add_provider_custom_models(self) -> None:
+        cfg = add_provider(
+            "custom",
+            "sk-custom",
+            base_url="https://custom.example/v1",
+            models=["custom/private-model", "custom/fast-model"],
+        )
+        assert cfg.providers["custom"].models == [
+            "custom/private-model",
+            "custom/fast-model",
+        ]
+
     def test_remove_provider(self) -> None:
         add_provider("deepseek", "sk-key")
         assert remove_provider("deepseek") is True
@@ -157,3 +169,32 @@ class TestCLI:
             capture_output=True, text=True,
         )
         assert "provider" in r.stdout
+
+    def test_provider_add_cli_accepts_custom_models(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        from uncommon_route.providers import cmd_provider
+
+        monkeypatch.setattr(
+            "uncommon_route.providers.verify_key",
+            lambda _base_url, _api_key: (True, "ok"),
+        )
+
+        cmd_provider([
+            "add",
+            "custom",
+            "sk-custom",
+            "--url",
+            "https://custom.example/v1",
+            "--models",
+            "custom/private-model, custom/fast-model",
+        ])
+
+        cfg = load_providers()
+        assert cfg.providers["custom"].models == [
+            "custom/private-model",
+            "custom/fast-model",
+        ]
+        assert "custom/private-model, custom/fast-model" in capsys.readouterr().out

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -13,7 +13,9 @@ from starlette.testclient import TestClient
 from uncommon_route.artifacts import ArtifactStore
 from uncommon_route.composition import CompositionPolicy
 from uncommon_route.connections_store import ConnectionsStore, InMemoryConnectionsStorage
+from uncommon_route.model_map import DiscoveredModel, ModelMapper
 from uncommon_route.model_experience import InMemoryModelExperienceStorage, ModelExperienceStore
+from uncommon_route.providers import ProviderEntry, ProvidersConfig
 from uncommon_route.proxy import (
     _extract_current_message,
     _extract_prompt,
@@ -25,10 +27,12 @@ from uncommon_route.routing_config_store import InMemoryRoutingConfigStorage, Ro
 import uncommon_route.scene_store as scene_store_module
 from uncommon_route.semantic import SemanticCallResult, SideChannelConfig, SideChannelTaskConfig
 from uncommon_route.spend_control import InMemorySpendControlStorage, SpendControl
-from uncommon_route.traces import InMemoryTraceStorage, TraceStore
+from uncommon_route.traces import InMemoryTraceStorage, RequestTrace, TraceStore
 from uncommon_route.router.types import (
     CapabilityLane,
     FallbackOption,
+    ModelCapabilities,
+    ModelPricing,
     RoutingDecision,
     RoutingMode,
     ServedQuality,
@@ -55,6 +59,22 @@ class QualityFallbackSemanticCompressor(FakeSemanticCompressor):
             estimated_cost=0.001,
             quality_fallbacks=3,
         )
+
+
+def _build_test_mapper(*model_ids: str) -> ModelMapper:
+    mapper = ModelMapper("https://api.example.test/v1")
+    for model_id in model_ids:
+        provider = model_id.split("/", 1)[0] if "/" in model_id else "unknown"
+        mapper._pool[model_id] = DiscoveredModel(
+            id=model_id,
+            provider=provider,
+            owned_by=provider,
+            pricing=ModelPricing(1.0, 5.0),
+            capabilities=ModelCapabilities(tool_calling=True, vision=False, reasoning=False),
+        )
+        mapper._upstream_models.add(model_id)
+    mapper._discovered = True
+    return mapper
 
 
 class TestPromptExtraction:
@@ -874,6 +894,191 @@ class TestFallbackAttribution:
             assert trace["fallback_reason"]
             assert trace["attempts_payload"][0]["selected_model"] == "primary/model"
             assert trace["attempts_payload"][1]["selected_model"] == "fallback/model"
+        finally:
+            asyncio.run(async_client.aclose())
+
+
+class TestRoutingContinuity:
+    def test_agent_tool_session_locks_route_pool_to_previous_model(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        routed: dict[str, object] = {}
+        captured: dict[str, object] = {}
+
+        def fake_route(*_args, **kwargs) -> RoutingDecision:
+            routed["available_models"] = list(kwargs.get("available_models") or [])
+            return RoutingDecision(
+                model="anthropic/claude-opus-4-5",
+                tier=Tier.COMPLEX,
+                capability_lane=CapabilityLane.GENERAL,
+                served_quality=ServedQuality.PREMIUM,
+                served_quality_target=ServedQuality.PREMIUM,
+                served_quality_floor=ServedQuality.BALANCED,
+                continuity_quality_floor=kwargs["routing_features"].continuity_quality_floor,
+                mode=RoutingMode.AUTO,
+                confidence=0.9,
+                method="pool",
+                reasoning="sticky session route",
+                cost_estimate=0.001,
+                baseline_cost=0.002,
+                savings=0.5,
+                routing_features=kwargs["routing_features"],
+            )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode("utf-8"))
+            return httpx.Response(
+                200,
+                json={
+                    "id": "chatcmpl_session_sticky",
+                    "object": "chat.completion",
+                    "created": 1,
+                    "model": "anthropic/claude-opus-4-5",
+                    "choices": [{
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+                },
+                headers={"content-type": "application/json"},
+            )
+
+        traces = TraceStore(storage=InMemoryTraceStorage(), now_fn=lambda: 1.0)
+        traces.record(RequestTrace(
+            timestamp=1.0,
+            request_id="prev_req",
+            requested_model="uncommon-route/auto",
+            model="anthropic/claude-opus-4-5",
+            status_code=200,
+            api_format="openai",
+            endpoint="chat_completions",
+            is_virtual=True,
+            session_id="agent-session",
+            step_type="tool-selection",
+            transport="openai-chat",
+            served_quality="premium",
+        ))
+
+        async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        monkeypatch.setattr("uncommon_route.proxy._get_client", lambda: async_client)
+        monkeypatch.setattr("uncommon_route.proxy.route", fake_route)
+
+        try:
+            app = create_app(
+                upstream="https://api.example.test/v1",
+                model_mapper=_build_test_mapper(
+                    "anthropic/claude-opus-4-5",
+                    "anthropic/claude-sonnet-4-6",
+                ),
+                trace_store=traces,
+                spend_control=SpendControl(storage=InMemorySpendControlStorage()),
+            )
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "uncommon-route/auto",
+                    "messages": [{"role": "user", "content": "Continue the coding task."}],
+                    "tools": [{
+                        "type": "function",
+                        "function": {"name": "read_file", "parameters": {"type": "object"}},
+                    }],
+                },
+                headers={"x-session-id": "agent-session"},
+            )
+
+            assert resp.status_code == 200
+            assert routed["available_models"] == ["anthropic/claude-opus-4-5"]
+            assert captured["body"]["model"] == "anthropic/claude-opus-4-5"
+            trace = traces.find(resp.headers["x-uncommon-route-request-id"])
+            assert trace is not None
+            assert "session-sticky=previous-model=anthropic/claude-opus-4-5" in trace["route_reasoning"]
+        finally:
+            asyncio.run(async_client.aclose())
+
+    def test_byok_custom_models_are_injected_into_virtual_route_pool(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        routed: dict[str, object] = {}
+        captured: dict[str, object] = {}
+
+        def fake_route(*_args, **kwargs) -> RoutingDecision:
+            routed["available_models"] = list(kwargs.get("available_models") or [])
+            return RoutingDecision(
+                model="custom/private-model",
+                tier=Tier.SIMPLE,
+                capability_lane=CapabilityLane.GENERAL,
+                served_quality=ServedQuality.ECONOMY,
+                served_quality_target=ServedQuality.ECONOMY,
+                served_quality_floor=ServedQuality.ECONOMY,
+                continuity_quality_floor=kwargs["routing_features"].continuity_quality_floor,
+                mode=RoutingMode.AUTO,
+                confidence=0.8,
+                method="byok-preferred (custom/private-model) | pool",
+                reasoning="custom BYOK route",
+                cost_estimate=0.001,
+                baseline_cost=0.002,
+                savings=0.5,
+                routing_features=kwargs["routing_features"],
+            )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["url"] = str(request.url)
+            captured["headers"] = dict(request.headers)
+            captured["body"] = json.loads(request.content.decode("utf-8"))
+            return httpx.Response(
+                200,
+                json={
+                    "id": "chatcmpl_byok_custom",
+                    "object": "chat.completion",
+                    "created": 1,
+                    "model": "custom/private-model",
+                    "choices": [{
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+                },
+                headers={"content-type": "application/json"},
+            )
+
+        providers = ProvidersConfig(providers={
+            "custom": ProviderEntry(
+                name="custom",
+                api_key="sk-custom",
+                base_url="https://custom.example/v1",
+                models=["custom/private-model"],
+            ),
+        })
+        async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        monkeypatch.setattr("uncommon_route.proxy._get_client", lambda: async_client)
+        monkeypatch.setattr("uncommon_route.proxy.route", fake_route)
+
+        try:
+            app = create_app(
+                upstream="https://api.example.test/v1",
+                providers_config=providers,
+                model_mapper=_build_test_mapper("openai/gpt-4o-mini"),
+                spend_control=SpendControl(storage=InMemorySpendControlStorage()),
+            )
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.post("/v1/chat/completions", json={
+                "model": "uncommon-route/auto",
+                "messages": [{"role": "user", "content": "hello"}],
+            })
+
+            assert resp.status_code == 200
+            assert routed["available_models"] == [
+                "openai/gpt-4o-mini",
+                "custom/private-model",
+            ]
+            assert captured["url"] == "https://custom.example/v1/chat/completions"
+            assert captured["headers"]["authorization"] == "Bearer sk-custom"
+            assert captured["body"]["model"] == "custom/private-model"
         finally:
             asyncio.run(async_client.aclose())
 

--- a/uncommon_route/cli.py
+++ b/uncommon_route/cli.py
@@ -254,7 +254,7 @@ Diagnostics helpers:
 def _print_provider_help() -> None:
     print("""Usage:
   uncommon-route provider list
-  uncommon-route provider add <name> <api_key> [--plan <plan>] [--url <base_url>]
+  uncommon-route provider add <name> <api_key> [--plan <plan>] [--url <base_url>] [--models <model1,model2>]
   uncommon-route provider remove <name>
   uncommon-route provider models
 

--- a/uncommon_route/providers.py
+++ b/uncommon_route/providers.py
@@ -244,7 +244,7 @@ def cmd_provider(args: list[str]) -> None:
 
     elif sub == "add":
         if len(args) < 3:
-            print("Usage: uncommon-route provider add <name> <api_key> [--plan <plan>]", file=sys.stderr)
+            print("Usage: uncommon-route provider add <name> <api_key> [--plan <plan>] [--url <base_url>] [--models <model1,model2>]", file=sys.stderr)
             print(f"  Known providers: {', '.join(KNOWN_BASE_URLS.keys())}", file=sys.stderr)
             sys.exit(1)
         name = args[1]
@@ -259,9 +259,18 @@ def cmd_provider(args: list[str]) -> None:
             idx = args.index("--url")
             if idx + 1 < len(args):
                 base_url = args[idx + 1]
+        models = None
+        if "--models" in args:
+            idx = args.index("--models")
+            if idx + 1 < len(args):
+                models = [
+                    item.strip()
+                    for item in args[idx + 1].split(",")
+                    if item.strip()
+                ]
 
-        add_provider(name, api_key, base_url=base_url, plan=plan)
-        models = PROVIDER_MODELS.get(name, [])
+        cfg = add_provider(name, api_key, base_url=base_url, models=models, plan=plan)
+        models = cfg.providers[name].models
         print(f"  Added provider: {name}")
         if models:
             print(f"  Models: {', '.join(models)}")

--- a/uncommon_route/proxy.py
+++ b/uncommon_route/proxy.py
@@ -2345,6 +2345,64 @@ def _supports_anthropic_thinking_payload(model: str) -> bool:
     return False
 
 
+def _merge_available_models(
+    available_models: list[str],
+    extra_models: list[str] | tuple[str, ...] | set[str] | None,
+) -> list[str]:
+    merged: list[str] = []
+    seen: set[str] = set()
+    for model in [*available_models, *(extra_models or ())]:
+        model_id = str(model or "").strip()
+        if not model_id or model_id in seen:
+            continue
+        seen.add(model_id)
+        merged.append(model_id)
+    return merged
+
+
+def _latest_successful_session_model(
+    *,
+    session_id: str | None,
+    trace_store: TraceStore,
+    step_types: tuple[str, ...] = ("tool-selection", "tool-result-followup", "general"),
+) -> str | None:
+    previous_trace = trace_store.latest_for_session(
+        session_id,
+        step_types=step_types,
+    ) if session_id else None
+    if (
+        previous_trace is None
+        or previous_trace.status_code >= 400
+    ):
+        return None
+    previous_model = str(previous_trace.model or "").strip()
+    if not previous_model or _is_virtual_model_name(previous_model):
+        return None
+    return previous_model
+
+
+def _raise_anthropic_thinking_affinity_error(
+    *,
+    previous_model: str,
+    reason: str,
+    available_models: list[str],
+) -> None:
+    raise RoutingInfeasibleError(
+        RoutingInfeasibility(
+            code=RoutingFailureCode.ROUTING_CONSTRAINTS_UNMET,
+            message=(
+                "Anthropic thinking blocks require the same model that created "
+                f"the prior signed thinking context ({previous_model}); {reason}."
+            ),
+            available_model_count=len(available_models),
+            candidate_count=0,
+            constraint_tags=("anthropic-thinking-context",),
+            failed_constraints=("anthropic-thinking-model-affinity",),
+            missing_capabilities=("signed-thinking-continuity",),
+        )
+    )
+
+
 def _filter_anthropic_thinking_context(
     *,
     available_models: list[str],
@@ -2358,10 +2416,8 @@ def _filter_anthropic_thinking_context(
         return [], ""
     if _requested_transport_name(api_format=api_format, endpoint_name=endpoint_name) != "anthropic-messages":
         return list(available_models), ""
-    if not (
-        _anthropic_thinking_enabled(source_body)
-        or _contains_anthropic_thinking_blocks(source_body)
-    ):
+    thinking_blocks_present = _contains_anthropic_thinking_blocks(source_body)
+    if not (_anthropic_thinking_enabled(source_body) or thinking_blocks_present):
         return list(available_models), ""
 
     previous_note = ""
@@ -2377,6 +2433,20 @@ def _filter_anthropic_thinking_context(
     ):
         previous_model = str(previous_trace.model or "").strip()
         if previous_model:
+            if thinking_blocks_present:
+                if previous_model not in available_models:
+                    _raise_anthropic_thinking_affinity_error(
+                        previous_model=previous_model,
+                        reason="that model is not available in the current route pool",
+                        available_models=available_models,
+                    )
+                if not _supports_anthropic_thinking_payload(previous_model):
+                    _raise_anthropic_thinking_affinity_error(
+                        previous_model=previous_model,
+                        reason="that model is not compatible with Anthropic thinking payloads",
+                        available_models=available_models,
+                    )
+                return [previous_model], f"thinking-context=locked-to-previous={previous_model}"
             if previous_model in available_models:
                 previous_note = f";previous={previous_model}"
             else:
@@ -2393,6 +2463,40 @@ def _filter_anthropic_thinking_context(
         f"thinking-context=compatible-pool({len(compatible_models)}/{len(available_models)})"
         f"{previous_note}"
     )
+
+
+def _should_use_session_sticky_model(features: RoutingFeatures) -> bool:
+    if not features.session_present:
+        return False
+    if features.step_type in {"tool-selection", "tool-result-followup"}:
+        return True
+    if features.has_tool_results:
+        return True
+    if features.agent_step_count >= 2:
+        return True
+    return bool(features.is_agentic and (features.needs_tool_calling or features.is_coding))
+
+
+def _filter_session_sticky_context(
+    *,
+    available_models: list[str],
+    session_id: str | None,
+    routing_features: RoutingFeatures,
+    trace_store: TraceStore,
+) -> tuple[list[str], str]:
+    if len(available_models) <= 1:
+        return list(available_models), ""
+    if not _should_use_session_sticky_model(routing_features):
+        return list(available_models), ""
+    previous_model = _latest_successful_session_model(
+        session_id=session_id,
+        trace_store=trace_store,
+    )
+    if not previous_model:
+        return list(available_models), ""
+    if previous_model in available_models:
+        return [previous_model], f"session-sticky=previous-model={previous_model}"
+    return list(available_models), f"session-sticky=previous-unavailable={previous_model}"
 
 
 def _reuse_anthropic_source_body(
@@ -3170,9 +3274,10 @@ def create_app(
         )
         ctx_features = extract_context_features(body, step_type, prompt)
         user_keyed = _providers.keyed_models() or None
-        available_models = _circuit_breaker.filter_available(
-            _mapper.routable_models if _mapper.discovered else list(DEFAULT_MODEL_PRICING.keys())
-        )
+        base_available_models = _mapper.routable_models if _mapper.discovered else list(DEFAULT_MODEL_PRICING.keys())
+        if user_keyed:
+            base_available_models = _merge_available_models(base_available_models, sorted(user_keyed))
+        available_models = _circuit_breaker.filter_available(base_available_models)
         available_models, transport_pool_note = _filter_transport_compatible_models(
             available_models=available_models,
             api_format="openai",
@@ -4214,9 +4319,10 @@ def create_app(
             user_keyed = _providers.keyed_models() or None
             route_pool_notes: list[str] = []
             try:
-                route_available_models = _circuit_breaker.filter_available(
-                    _mapper.routable_models if _mapper.discovered else list(DEFAULT_MODEL_PRICING.keys())
-                )
+                base_available_models = _mapper.routable_models if _mapper.discovered else list(DEFAULT_MODEL_PRICING.keys())
+                if user_keyed:
+                    base_available_models = _merge_available_models(base_available_models, sorted(user_keyed))
+                route_available_models = _circuit_breaker.filter_available(base_available_models)
                 if _active_scene and not _active_scene.hard_pin:
                     scene_pool = _active_scene.model_pool()
                     available_scene_models = [m for m in scene_pool if m in route_available_models]
@@ -4245,6 +4351,14 @@ def create_app(
                 )
                 if thinking_lock_note:
                     route_pool_notes.append(thinking_lock_note)
+                route_available_models, session_sticky_note = _filter_session_sticky_context(
+                    available_models=route_available_models,
+                    session_id=session_id,
+                    routing_features=routing_features,
+                    trace_store=_traces,
+                )
+                if session_sticky_note:
+                    route_pool_notes.append(session_sticky_note)
 
                 if _active_scene and _active_scene.hard_pin:
                     from uncommon_route.router.types import (
@@ -4751,7 +4865,7 @@ def create_app(
             resolved_model = model_name
             if not attempt_provider_entry:
                 resolved_model = _mapper.resolve(model_name)
-                attempt_upstream_body["model"] = resolved_model
+            attempt_upstream_body["model"] = resolved_model
 
             attempt_has_tools = bool(
                 attempt_upstream_body.get("tools")

--- a/uncommon_route/session.py
+++ b/uncommon_route/session.py
@@ -1,8 +1,7 @@
 """Session identity utilities.
 
-Provides ``derive_session_id`` for cache key generation and
-composition checkpoint tracking.  Routing no longer uses sticky
-sessions — every request is routed independently by the pool scorer.
+Provides ``derive_session_id`` for cache key generation, composition
+checkpoint tracking, and routing continuity for agent/tool sessions.
 """
 
 from __future__ import annotations
@@ -16,7 +15,8 @@ from typing import Any
 def derive_session_id(messages: list[dict[str, Any]]) -> str | None:
     """Derive a session ID from the first user message (SHA-256 prefix).
 
-    Used for cache key grouping and composition checkpoints, not routing.
+    Used for cache key grouping, composition checkpoints, and agent/tool
+    session continuity.
 
     Skips boilerplate user messages whose content is identical across
     sessions for the same workspace — notably Codex CLI's


### PR DESCRIPTION
## Summary
- hard-lock Anthropic thinking-block follow-up turns to the previous signed-thinking model, and fail closed if that model is unavailable
- add session-sticky routing for agent/tool sessions so Thompson sampling cannot switch models mid-session
- inject BYOK provider models into the virtual routing pool, preserve selected BYOK model IDs in forwarded requests, and add CLI --models support

Closes #11
Closes #15
Closes #20

## Verification
- python -m ruff check uncommon_route/proxy.py uncommon_route/providers.py uncommon_route/session.py tests/test_anthropic_compat.py tests/test_proxy.py tests/test_providers.py
- python -m pytest -q
- live Commonstack e2e: /health 200; /v1/chat/completions 200 via uncommon-route/auto with upstream model google/gemini-2.5-flash