### PR TITLE
Strip all leading system-reminder wrappers in conversation view

### DIFF
--- a/frontend/dashboard/src/components/conversation/MessageBubble.tsx
+++ b/frontend/dashboard/src/components/conversation/MessageBubble.tsx
@@ -92,15 +92,13 @@ export default function MessageBubble({
 
 function UserBubble({ message }: { message: ConversationMessage }) {
   const [showWrapper, setShowWrapper] = useState(false);
-  const hasWrapper = SYSTEM_REMINDER_PATTERN.test(message.text);
   let displayText = message.text;
   let wrapperText = "";
-  if (hasWrapper) {
-    const m = message.text.match(/^([\s\S]*?<\/(system-reminder|command-name|local-command-stdout|command-message|command-args)>\s*)/i);
-    if (m) {
-      wrapperText = m[1];
-      displayText = message.text.slice(m[1].length);
-    }
+  while (SYSTEM_REMINDER_PATTERN.test(displayText)) {
+    const m = displayText.match(/^([\s\S]*?<\/(system-reminder|command-name|local-command-stdout|command-message|command-args)>\s*)/i);
+    if (!m) break;
+    wrapperText += m[1];
+    displayText = displayText.slice(m[1].length);
   }
 
   return (

--- a/frontend/dashboard/src/components/conversation/TerminalView.tsx
+++ b/frontend/dashboard/src/components/conversation/TerminalView.tsx
@@ -88,17 +88,15 @@ function ContinuationRow({ children }: { children: ReactNode }) {
 
 function UserRow({ message }: { message: ConversationMessage }) {
   const [showWrapper, setShowWrapper] = useState(false);
-  const hasWrapper = SYSTEM_REMINDER_PATTERN.test(message.text);
   let displayText = message.text;
   let wrapperText = "";
-  if (hasWrapper) {
-    const m = message.text.match(
+  while (SYSTEM_REMINDER_PATTERN.test(displayText)) {
+    const m = displayText.match(
       /^([\s\S]*?<\/(system-reminder|command-name|local-command-stdout|command-message|command-args)>\s*)/i,
     );
-    if (m) {
-      wrapperText = m[1];
-      displayText = message.text.slice(m[1].length);
-    }
+    if (!m) break;
+    wrapperText += m[1];
+    displayText = displayText.slice(m[1].length);
   }
   return (
     <div className="mt-4 flex gap-2 rounded-compact bg-n-surface px-2 py-1">


### PR DESCRIPTION
## Summary
- Fix dashboard conversation view leaking later `<system-reminder>` blocks into the user-visible body when a message contains multiple consecutive wrappers.
- The wrapper-extraction regex used a lazy `*?` and only stripped the first reminder; remaining ones rendered as plain text below the `⚙ SHOW REMINDER` toggle.
- Loop the match in both `MessageBubble.tsx` and `TerminalView.tsx` until no leading wrapper remains, so the toggle controls all of them.

## Test plan
- [ ] Open a stored session whose user message has multiple stacked `<system-reminder>` blocks (e.g. session `1d6e3caa`); verify only the toggle is visible and clicking it reveals every reminder.
- [ ] Confirm a message with no wrapper still renders normally.
- [ ] Confirm a message with a single wrapper still behaves as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)