### PR TITLE
Polish README for launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ uncommon-route serve
 With the Dashboard, you can:
 
 - Preview how a prompt will be classified before sending it.
-- Inspect each routed request by session, including model, latency, cost, and signal readout.
+- Inspect each routed request per session, including model, latency, cost, and signal readout.
 - See which complexity classes and models are driving your spend.
 - Tune routing policy, fallbacks, budgets, provider keys, and model pools.
 - Rate decisions as `too strong`, `just right`, or `too weak`; those labels train a local model overlay without touching the base model.
@@ -166,11 +166,11 @@ resp = client.chat.completions.create(
 
 Each request runs through three local signals. The router first classifies task complexity, then picks the best model from your configured upstream.
 
-| Signal | What it looks at | Typical overhead |
+| Signal | What it looks at | Runtime note |
 |---|---|---:|
-| Metadata | Conversation structure, tool use, context depth | <1ms |
-| Embedding | BGE classifier over the request, recent agent state, and metadata; KNN fallback when uncertain | ~25-35ms |
-| Structural | Text and conversation complexity; active only when needed, shadow-tracked otherwise | <1ms |
+| Metadata | Conversation structure, tool use, context depth | Cheap |
+| Embedding | BGE classifier over the request, recent agent state, and metadata; KNN fallback when uncertain | Depends on local runtime assets and cache state |
+| Structural | Text and conversation complexity; active only when needed, shadow-tracked otherwise | Cheap |
 
 The signals vote, and the ensemble decides the complexity class. The router then weighs capabilities, transport, upstream availability, and price. From the matching candidates, it picks the lowest-cost option. Unknown upstream pricing is handled conservatively.
 
@@ -193,7 +193,7 @@ UncommonRoute is evaluated on [TwinRouterBench](https://github.com/CommonstackAI
 
 Put another way: this isn't a "spend less, solve fewer tasks" trade-off. On this split, UncommonRoute matched Opus-only on tasks solved while cutting realized API spend by 53%.
 
-"Tasks solved" means the number of successfully resolved tasks out of 100 held-out SWE-bench Verified cases. "API cost" is realized model-call spend and doesn't include the penalty cost reported in Table 4.
+"Tasks solved" means the number of successfully resolved tasks out of 100 held-out SWE-bench Verified cases. "API cost" is realized model-call spend and doesn't include the penalty cost reported in Table 3 of the paper.
 
 ### Reproduce
 
@@ -206,14 +206,7 @@ python scripts/bench_overhead.py --iterations 50 --json
 
 ### Routing Overhead
 
-Local CPU, warm process:
-
-| Metric | Latency |
-|---|:---:|
-| p50 | 25.6ms |
-| p90 | 32.1ms |
-
-Cold start loads the embedding model and can take a few seconds. After warm-up, a single `route()` call typically takes tens of milliseconds.
+Routing overhead depends on hardware, installed runtime assets, and which signals are active. Run the command above to report cold start plus warm-process p50 / p90 / p99 for the current checkout.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Plug it into Claude Code, Cursor, Codex, or the OpenAI SDK. It runs locally and routes each request to the right model.
 
-<strong>75/100 tasks solved vs 74/100 with Opus-only, at 53% lower API cost.</strong>
+<strong>Trained router: 75/100 tasks solved vs 74/100 with Opus-only, at 53% lower API cost.</strong>
 
 <a href="https://pypi.org/project/uncommon-route/"><img src="https://img.shields.io/pypi/v/uncommon-route?style=flat-square&logo=pypi&logoColor=white&label=PyPI" alt="PyPI"></a>
 <a href="https://www.npmjs.com/package/@anjieyang/uncommon-route"><img src="https://img.shields.io/npm/v/@anjieyang/uncommon-route?style=flat-square&logo=npm&logoColor=white&label=npm" alt="npm"></a>
@@ -24,12 +24,12 @@ Plug it into Claude Code, Cursor, Codex, or the OpenAI SDK. It runs locally and 
 <a href="#how-it-works">How It Works</a> ·
 <a href="#faq">FAQ</a>
 
-| | Opus-only | UncommonRoute | Saved |
+| | Opus-only | UncommonRoute (trained) | Saved |
 |---|:---:|:---:|:---:|
 | Tasks solved | 74 / 100 | **75 / 100** | Matched |
 | API cost | $54.73 | **$25.66** | **-53%** |
 
-<sub>Numbers from a held-out 100-case SWE-bench Verified split in <a href="https://github.com/CommonstackAI/TwinRouterBench">TwinRouterBench</a>. Reproduction commands below.</sub>
+<sub>Numbers from the trained UncommonRoute router on a held-out 100-case SWE-bench Verified split in <a href="https://github.com/CommonstackAI/TwinRouterBench">TwinRouterBench</a>. Details below.</sub>
 
 </div>
 
@@ -182,25 +182,27 @@ UncommonRoute also learns from local feedback: high-confidence agreement grows t
 
 ## Benchmark
 
-UncommonRoute is evaluated on [TwinRouterBench](https://github.com/CommonstackAI/TwinRouterBench): 970 router-visible prefixes from 520 instances across SWE-Bench, BFCL, mtRAG, QMSum, and PinchBench, with execution-verified target tier labels. The end-to-end validation below uses a 100-case held-out SWE-bench Verified split.
+UncommonRoute is evaluated on [TwinRouterBench](https://github.com/CommonstackAI/TwinRouterBench): 970 router-visible prefixes from 520 instances across SWE-Bench, BFCL, mtRAG, QMSum, and PinchBench, with execution-verified target tier labels. TwinRouterBench scores four internal tiers (`low` / `mid` / `mid_high` / `high`); the product UI presents routing decisions as `simple` / `medium` / `complex`.
+
+The end-to-end validation below uses a 100-case held-out SWE-bench Verified split and reports the trained-router row from Table 3 of the paper.
 
 ### Matched task quality, 53% lower API cost
 
 | Policy | Tasks solved | API cost | vs Opus-only |
 |---|:---:|:---:|:---:|
 | Opus 4.6 only | 74 / 100 | $54.73 | — |
-| **UncommonRoute** | **75 / 100** | **$25.66** | **-53%** |
+| **UncommonRoute (trained)** | **75 / 100** | **$25.66** | **-53%** |
 
-Put another way: this isn't a "spend less, solve fewer tasks" trade-off. On this split, UncommonRoute matched Opus-only on tasks solved while cutting realized API spend by 53%.
+Put another way: this isn't a "spend less, solve fewer tasks" trade-off. On this split, the trained UncommonRoute router matched Opus-only on tasks solved while cutting realized API spend by 53%.
 
 "Tasks solved" means the number of successfully resolved tasks out of 100 held-out SWE-bench Verified cases. "API cost" is realized model-call spend and doesn't include the penalty cost reported in Table 3 of the paper.
 
 ### Reproduce
 
+Full Table 3 reproduction lives in the TwinRouterBench release package because it needs the locked dynamic split, model pool, pricing files, and scorer. This repo includes the local router and an overhead check:
+
 ```bash
 python -m pip install -e ".[dev]"
-python -m pip install "git+https://github.com/CommonstackAI/TwinRouterBench.git"
-python scripts/eval_v2.py --split holdout
 python scripts/bench_overhead.py --iterations 50 --json
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 **Cut your API bill in half without giving up performance.**
 
-Plug it into Claude Code, Cursor, Codex, or the OpenAI SDK. It runs locally and routes each request to the right model.
+UncommonRoute plugs into Claude Code, Cursor, Codex, or the OpenAI SDK. It runs locally and routes each request to the right model.
 
-<strong>Trained router: 75/100 tasks solved vs 74/100 with Opus-only, at 53% lower API cost.</strong>
+<strong>On a held-out 100-case SWE-bench Verified split, the trained router solved 75/100 tasks vs 74/100 with Opus-only, at 53% lower API cost.</strong>
 
 <a href="https://pypi.org/project/uncommon-route/"><img src="https://img.shields.io/pypi/v/uncommon-route?style=flat-square&logo=pypi&logoColor=white&label=PyPI" alt="PyPI"></a>
 <a href="https://www.npmjs.com/package/@anjieyang/uncommon-route"><img src="https://img.shields.io/npm/v/@anjieyang/uncommon-route?style=flat-square&logo=npm&logoColor=white&label=npm" alt="npm"></a>
@@ -27,7 +27,7 @@ Plug it into Claude Code, Cursor, Codex, or the OpenAI SDK. It runs locally and 
 | | Opus-only | UncommonRoute (trained) | Saved |
 |---|:---:|:---:|:---:|
 | Tasks solved | 74 / 100 | **75 / 100** | Matched |
-| API cost | $54.73 | **$25.66** | **-53%** |
+| API cost | $54.73 | **$25.66** | **−53%** |
 
 <sub>Numbers from the trained UncommonRoute router on a held-out 100-case SWE-bench Verified split in <a href="https://github.com/CommonstackAI/TwinRouterBench">TwinRouterBench</a>. Details below.</sub>
 
@@ -98,7 +98,7 @@ Routing happens locally and independently for each agent step. You can inspect e
 
 ## Visual Routing
 
-UncommonRoute isn't just a pass-through proxy. The Dashboard records and explains every routing decision: whether the request was classified as simple, medium, or complex, which model was selected, what it cost, and what you can tune next.
+UncommonRoute isn't just a pass-through proxy. The Dashboard records and explains every routing decision: whether the request was classified as simple, medium, or complex, which model was selected, what it cost, and what's adjustable.
 
 ```bash
 uncommon-route serve
@@ -111,9 +111,9 @@ With the Dashboard, you can:
 - Inspect each routed request per session, including model, latency, cost, and signal readout.
 - See which complexity classes and models are driving your spend.
 - Tune routing policy, fallbacks, budgets, provider keys, and model pools.
-- Rate decisions as `too strong`, `just right`, or `too weak`; those labels train a local model overlay without touching the base model.
+- Rate decisions as `too strong`, `just right`, or `too weak`; those labels train a thin local overlay on top of the base classifier without touching the base model.
 
-That Feedback loop is the part that matters after day one. If UncommonRoute routes something too aggressively or too conservatively, you can correct it in the Dashboard. Training happens locally, the base model stays intact, and you can roll back the overlay anytime.
+That Feedback loop is the part that matters after day one. If UncommonRoute routes something too aggressively or too conservatively, you can correct it in the Dashboard. Training happens locally, the base model stays intact, and the overlay can be rolled back anytime.
 
 ---
 
@@ -157,7 +157,7 @@ resp = client.chat.completions.create(
 | Explainable decisions | See complexity, confidence, signal readout, selected model, and cost for each route |
 | Adjustable policy | Use `auto` / `fast` / `best`, or override simple / medium / complex with primary and fallback models |
 | Spend caps | Set per-request, hourly, or daily API spend limits |
-| Local training | Feedback updates a local model overlay; the base model is never overwritten and can be restored anytime |
+| Local training | Feedback updates a local model overlay. The base model is never overwritten, and the overlay can be rolled back anytime |
 | Drop-in integration | Claude Code, Cursor, Codex, OpenAI SDK, and OpenClaw work without application code changes |
 
 ---
@@ -191,7 +191,7 @@ The end-to-end validation below uses a 100-case held-out SWE-bench Verified spli
 | Policy | Tasks solved | API cost | vs Opus-only |
 |---|:---:|:---:|:---:|
 | Opus 4.6 only | 74 / 100 | $54.73 | — |
-| **UncommonRoute (trained)** | **75 / 100** | **$25.66** | **-53%** |
+| **UncommonRoute (trained)** | **75 / 100** | **$25.66** | **−53%** |
 
 Put another way: this isn't a "spend less, solve fewer tasks" trade-off. On this split, the trained UncommonRoute router matched Opus-only on tasks solved while cutting realized API spend by 53%.
 
@@ -208,7 +208,7 @@ python scripts/bench_overhead.py --iterations 50 --json
 
 ### Routing Overhead
 
-Routing overhead depends on hardware, installed runtime assets, and which signals are active. Run the command above to report cold start plus warm-process p50 / p90 / p99 for the current checkout.
+Routing overhead depends on hardware, installed runtime assets, and which signals are active. Run the command above to measure cold start plus warm-process p50 / p90 / p99 in your environment.
 
 ---
 
@@ -404,7 +404,7 @@ Yes. You can use Commonstack as a managed upstream or register your own provider
 <details>
 <summary><strong>Does feedback train anything?</strong></summary>
 
-Yes. Feedback updates a local model overlay and labeled traces can calibrate runtime confidence. The base model is never overwritten, and you can roll back the overlay.
+Yes. Feedback updates a local model overlay, and labeled traces can calibrate runtime confidence. The base model is never overwritten, and the overlay can be rolled back anytime.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -98,26 +98,22 @@ Routing happens locally and independently for each agent step. You can inspect e
 
 ## Visual Routing
 
-UncommonRoute isn't just a pass-through proxy. The Dashboard records and explains every routing decision: whether the request was classified as simple, medium, or complex, which model was selected, its actual or estimated cost, and how to tune the policy.
+UncommonRoute isn't just a pass-through proxy. The Dashboard records and explains every routing decision: whether the request was classified as simple, medium, or complex, which model was selected, what it cost, and what you can tune next.
 
 ```bash
 uncommon-route serve
 # -> http://localhost:8403/dashboard/
 ```
 
-| Page | What it does |
-|---|---|
-| Home | Live requests, complexity distribution, model choices, and cost changes |
-| Playground | Type a prompt and preview complexity, confidence, estimated cost, and signal readout |
-| Explain | Inspect each routing decision per session, including model, latency, and cost |
-| Activity | See request complexity, served quality, transport paths, capability lanes, model usage, and cost distribution |
-| Routing | Configure `auto` / `fast` / `best`, or set primary and fallback models per complexity tier |
-| Models | Browse the active model pool, providers, capability tags, and input / output prices |
-| Connections | Manage the primary upstream and BYOK provider keys, and verify connection status |
-| Budget | Set per-request, hourly, or daily spend limits |
-| Feedback | Mark routes as `too strong`, `just right`, or `too weak` to improve the local classifier |
+With the Dashboard, you can:
 
-To kick the tires: type a prompt in Playground, inspect the predicted complexity, confidence, and cost estimate, then open Explain / Activity to trace real routing decisions.
+- Preview how a prompt will be classified before sending it.
+- Inspect each routed request by session, including model, latency, cost, and signal readout.
+- See which complexity classes and models are driving your spend.
+- Tune routing policy, fallbacks, budgets, provider keys, and model pools.
+- Rate decisions as `too strong`, `just right`, or `too weak`; those labels train a local model overlay without touching the base model.
+
+That Feedback loop is the part that matters after day one. If UncommonRoute routes something too aggressively or too conservatively, you can correct it in the Dashboard. Training happens locally, the base model stays intact, and you can roll back the overlay anytime.
 
 ---
 
@@ -161,7 +157,7 @@ resp = client.chat.completions.create(
 | Explainable decisions | See complexity, confidence, signal readout, selected model, and cost for each route |
 | Adjustable policy | Use `auto` / `fast` / `best`, or override simple / medium / complex with primary and fallback models |
 | Spend caps | Set per-request, hourly, or daily API spend limits |
-| Local feedback | Mark routes as too strong, just right, or too weak to improve the classifier locally |
+| Local training | Feedback updates a local model overlay; the base model is never overwritten and can be restored anytime |
 | Drop-in integration | Claude Code, Cursor, Codex, OpenAI SDK, and OpenClaw work without application code changes |
 
 ---
@@ -265,6 +261,34 @@ UncommonRoute also learns from local feedback: high-confidence agreement grows t
 - You only call LLMs occasionally and your bill is already small.
 - You expect a router to make low-cost models fundamentally more capable. UncommonRoute doesn't make that claim.
 - You want every request to use the strongest model, no matter what. You can use `uncommon-route/best`, but the savings will be smaller.
+
+---
+
+## FAQ
+
+**Will this hurt quality?**
+
+UncommonRoute doesn't blindly chase the cheapest model. Uncertain or high-risk requests escalate to stronger models, and the held-out SWE-bench Verified result above shows matched task quality on that split.
+
+**Where do my prompts go?**
+
+Routing runs locally. Your prompt is sent to the upstream provider you configure, not to a separate hosted routing service.
+
+**What happens when the router is unsure?**
+
+It falls back conservatively: low-confidence decisions escalate instead of quietly sending complex work to an underpowered model.
+
+**Can I override the routing?**
+
+Yes. Use `auto`, `fast`, or `best`, or configure primary and fallback models for simple / medium / complex requests.
+
+**Can I use my own API keys?**
+
+Yes. You can use Commonstack as a managed upstream or register your own provider keys with BYOK.
+
+**Does feedback train anything?**
+
+Yes. Feedback updates a local model overlay and labeled traces can calibrate runtime confidence. The base model is never overwritten, and you can roll back the overlay.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ UncommonRoute plugs into Claude Code, Cursor, Codex, and the OpenAI SDK. It runs
 <br><br>
 
 <a href="#quick-start">Quick Start</a> ·
+<a href="#how-uncommonroute-saves-money">Savings</a> ·
+<a href="#why-uncommonroute">Why</a> ·
 <a href="#visual-routing">Dashboard</a> ·
-<a href="#supported-clients">Clients</a> ·
 <a href="#benchmark">Benchmark</a> ·
 <a href="#privacy">Privacy</a>
 
@@ -64,6 +65,34 @@ uncommon-route doctor
 - **Need a specific Python version**: `pipx install --python python3.12 uncommon-route`
 
 </details>
+
+---
+
+## How UncommonRoute Saves Money
+
+The savings don't come from using less AI. They come from not sending easy requests to frontier models.
+
+```text
+"hello"                         -> simple
+"fix a typo in the README"       -> simple
+"find and fix this failing test" -> medium
+"refactor this 500-line module"  -> medium / complex
+"design a distributed scheduler" -> complex
+```
+
+Simple requests go to lightweight models. Medium requests go to capable mid-tier models. Complex requests escalate to the strongest model you've configured. Each decision is made per request, so a single conversation isn't tied to one model.
+
+---
+
+## Why UncommonRoute
+
+If you use AI agents for coding every day, a lot of that spend goes toward work that doesn't need the most expensive model: typo fixes, small edits, simple test runs, short explanations.
+
+UncommonRoute does one thing. It doesn't replace Claude Code, Cursor, or Codex, and doesn't try to make cheaper models smarter. It focuses on one decision:
+
+> Which model is the right fit for this request?
+
+Routing happens locally and independently for each agent step. You can inspect every decision in the Dashboard instead of trusting a black-box proxy.
 
 ---
 
@@ -119,34 +148,6 @@ resp = client.chat.completions.create(
     messages=msgs,
 )
 ```
-
----
-
-## How UncommonRoute Saves Money
-
-The savings don't come from using less AI. They come from not sending easy requests to frontier models.
-
-```text
-"hello"                         -> simple
-"fix a typo in the README"       -> simple
-"find and fix this failing test" -> medium
-"refactor this 500-line module"  -> medium / complex
-"design a distributed scheduler" -> complex
-```
-
-Simple requests go to lightweight models. Medium requests go to capable mid-tier models. Complex requests escalate to the strongest model you've configured. Each decision is made per request, so a single conversation isn't tied to one model.
-
----
-
-## Why UncommonRoute
-
-If you use AI agents for coding every day, a lot of that spend goes toward work that doesn't need the most expensive model: typo fixes, small edits, simple test runs, short explanations.
-
-UncommonRoute does one thing. It doesn't replace Claude Code, Cursor, or Codex, and doesn't try to make cheaper models smarter. It focuses on one decision:
-
-> Which model is the right fit for this request?
-
-Routing happens locally and independently for each agent step. You can inspect every decision in the Dashboard instead of trusting a black-box proxy.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,24 @@ resp = client.chat.completions.create(
 
 ---
 
+## How It Works
+
+Each request runs through three local signals. The router first classifies task complexity, then picks the best model from your configured upstream.
+
+| Signal | What it looks at | Typical overhead |
+|---|---|---:|
+| Metadata | Conversation structure, tool use, context depth | <1ms |
+| Embedding | BGE classifier over the request, recent agent state, and metadata; KNN fallback when uncertain | ~25-35ms |
+| Structural | Text and conversation complexity; active only when needed, shadow-tracked otherwise | <1ms |
+
+The signals vote, and the ensemble decides the complexity class. The router then weighs capabilities, transport, upstream availability, and price. From the matching candidates, it picks the lowest-cost option. Unknown upstream pricing is handled conservatively.
+
+Routing is **per request / per agent step**. The session isn't pinned to one model. Protocol constraints, such as Anthropic thinking continuations, are still respected.
+
+UncommonRoute also learns from local feedback: high-confidence agreement grows the embedding index, while low-confidence predictions escalate instead of silently sending complex work to an underpowered model.
+
+---
+
 ## Benchmark
 
 UncommonRoute is evaluated on [TwinRouterBench](https://github.com/CommonstackAI/TwinRouterBench): 970 router-visible prefixes from 520 instances across SWE-Bench, BFCL, mtRAG, QMSum, and PinchBench, with execution-verified target tier labels. The end-to-end validation below uses a 100-case held-out SWE-bench Verified split.
@@ -199,39 +217,13 @@ Cold start loads the embedding model and can take a few seconds. After warm-up, 
 
 ---
 
-## How It Works
+## Who It's For
 
-Each request runs through three local signals. The router first classifies task complexity, then picks the best model from your configured upstream.
-
-| Signal | What it looks at | Typical overhead |
-|---|---|---:|
-| Metadata | Conversation structure, tool use, context depth | <1ms |
-| Embedding | BGE classifier over the request, recent agent state, and metadata; KNN fallback when uncertain | ~25-35ms |
-| Structural | Text and conversation complexity; active only when needed, shadow-tracked otherwise | <1ms |
-
-The signals vote, and the ensemble decides the complexity class. The router then weighs capabilities, transport, upstream availability, and price. From the matching candidates, it picks the lowest-cost option. Unknown upstream pricing is handled conservatively.
-
-Routing is **per request / per agent step**. The session isn't pinned to one model. Protocol constraints, such as Anthropic thinking continuations, are still respected.
-
-UncommonRoute also learns from local feedback: high-confidence agreement grows the embedding index, while low-confidence predictions escalate instead of silently sending complex work to an underpowered model.
-
----
-
-## Privacy
-
-Routing runs on your machine. **Your prompts don't go through a separate routing service; they're sent only to the upstream provider you configure.**
-
-```bash
-uncommon-route telemetry status
-```
-
-Diagnostic exports are local by default:
-
-```bash
-uncommon-route support bundle
-```
-
-The redacted support bundle is written to `~/.uncommon-route/support/`. It leaves your machine only if you choose to share it.
+- You use Claude Code, Cursor, Codex, or another coding agent every day.
+- Most of your spend goes to frontier models, but many requests don't need that tier.
+- You want lower API cost without sending prompts to an extra hosted router.
+- You need routing at request granularity, not one model choice for the entire session.
+- You want routing that is explainable, adjustable, and feedback-driven.
 
 ---
 
@@ -245,24 +237,6 @@ uncommon-route spend status
 ```
 
 You can also configure per-request, hourly, or daily limits in the Dashboard. Once a limit is reached, requests fall back to the lowest-cost available tier instead of failing outright.
-
----
-
-## Who It's For
-
-- You use Claude Code, Cursor, Codex, or another coding agent every day.
-- Most of your spend goes to frontier models, but many requests don't need that tier.
-- You want lower API cost without sending prompts to an extra hosted router.
-- You need routing at request granularity, not one model choice for the entire session.
-- You want routing that is explainable, adjustable, and feedback-driven.
-
----
-
-## Who It's Not For
-
-- You only call LLMs occasionally and your bill is already small.
-- You expect a router to make low-cost models fundamentally more capable. UncommonRoute doesn't make that claim.
-- You want every request to use the strongest model, no matter what. You can use `uncommon-route/best`, but the savings will be smaller.
 
 ---
 
@@ -317,6 +291,24 @@ Supported providers: `commonstack`, `openai`, `anthropic`, `google`, `xai`, `min
 | `UNCOMMON_ROUTE_PORT` | Local proxy port, default 8403 |
 
 </details>
+
+---
+
+## Privacy
+
+Routing runs on your machine. **Your prompts don't go through a separate routing service; they're sent only to the upstream provider you configure.**
+
+```bash
+uncommon-route telemetry status
+```
+
+Diagnostic exports are local by default:
+
+```bash
+uncommon-route support bundle
+```
+
+The redacted support bundle is written to `~/.uncommon-route/support/`. It leaves your machine only if you choose to share it.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 **Cut your API bill in half without giving up performance.**
 
-UncommonRoute plugs into Claude Code, Cursor, Codex, and the OpenAI SDK. It runs locally, analyzes task complexity, conversation structure, tool use, available models, and budget constraints, then routes each request to the right model for the job.
+Plug it into Claude Code, Cursor, Codex, or the OpenAI SDK. It runs locally and routes each request to the right model.
 
-<strong>On a held-out 100-case SWE-bench Verified split, UncommonRoute solved 75/100 tasks vs 74/100 for Opus-only. With task quality matched, API cost dropped by 53%.</strong>
+<strong>75/100 tasks solved vs 74/100 with Opus-only, at 53% lower API cost.</strong>
 
 <a href="https://pypi.org/project/uncommon-route/"><img src="https://img.shields.io/pypi/v/uncommon-route?style=flat-square&logo=pypi&logoColor=white&label=PyPI" alt="PyPI"></a>
 <a href="https://www.npmjs.com/package/@anjieyang/uncommon-route"><img src="https://img.shields.io/npm/v/@anjieyang/uncommon-route?style=flat-square&logo=npm&logoColor=white&label=npm" alt="npm"></a>

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ UncommonRoute plugs into Claude Code, Cursor, Codex, and the OpenAI SDK. It runs
 
 <a href="#quick-start">Quick Start</a> ·
 <a href="#how-uncommonroute-saves-money">Savings</a> ·
-<a href="#why-uncommonroute">Why</a> ·
 <a href="#visual-routing">Dashboard</a> ·
 <a href="#benchmark">Benchmark</a> ·
-<a href="#privacy">Privacy</a>
+<a href="#how-it-works">How It Works</a> ·
+<a href="#faq">FAQ</a>
 
 | | Opus-only | UncommonRoute | Saved |
 |---|:---:|:---:|:---:|
@@ -199,6 +199,24 @@ Cold start loads the embedding model and can take a few seconds. After warm-up, 
 
 ---
 
+## How It Works
+
+Each request runs through three local signals. The router first classifies task complexity, then picks the best model from your configured upstream.
+
+| Signal | What it looks at | Typical overhead |
+|---|---|---:|
+| Metadata | Conversation structure, tool use, context depth | <1ms |
+| Embedding | BGE classifier over the request, recent agent state, and metadata; KNN fallback when uncertain | ~25-35ms |
+| Structural | Text and conversation complexity; active only when needed, shadow-tracked otherwise | <1ms |
+
+The signals vote, and the ensemble decides the complexity class. The router then weighs capabilities, transport, upstream availability, and price. From the matching candidates, it picks the lowest-cost option. Unknown upstream pricing is handled conservatively.
+
+Routing is **per request / per agent step**. The session isn't pinned to one model. Protocol constraints, such as Anthropic thinking continuations, are still respected.
+
+UncommonRoute also learns from local feedback: high-confidence agreement grows the embedding index, while low-confidence predictions escalate instead of silently sending complex work to an underpowered model.
+
+---
+
 ## Privacy
 
 Routing runs on your machine. **Your prompts don't go through a separate routing service; they're sent only to the upstream provider you configure.**
@@ -230,24 +248,6 @@ You can also configure per-request, hourly, or daily limits in the Dashboard. On
 
 ---
 
-## How It Works
-
-Each request runs through three local signals. The router first classifies task complexity, then picks the best model from your configured upstream.
-
-| Signal | What it looks at | Typical overhead |
-|---|---|---:|
-| Metadata | Conversation structure, tool use, context depth | <1ms |
-| Embedding | BGE classifier over the request, recent agent state, and metadata; KNN fallback when uncertain | ~25-35ms |
-| Structural | Text and conversation complexity; active only when needed, shadow-tracked otherwise | <1ms |
-
-The signals vote, and the ensemble decides the complexity class. The router then weighs capabilities, transport, upstream availability, and price. From the matching candidates, it picks the lowest-cost option. Unknown upstream pricing is handled conservatively.
-
-Routing is **per request / per agent step**. The session isn't pinned to one model. Protocol constraints, such as Anthropic thinking continuations, are still respected.
-
-UncommonRoute also learns from local feedback: high-confidence agreement grows the embedding index, while low-confidence predictions escalate instead of silently sending complex work to an underpowered model.
-
----
-
 ## Who It's For
 
 - You use Claude Code, Cursor, Codex, or another coding agent every day.
@@ -256,39 +256,13 @@ UncommonRoute also learns from local feedback: high-confidence agreement grows t
 - You need routing at request granularity, not one model choice for the entire session.
 - You want routing that is explainable, adjustable, and feedback-driven.
 
+---
+
 ## Who It's Not For
 
 - You only call LLMs occasionally and your bill is already small.
 - You expect a router to make low-cost models fundamentally more capable. UncommonRoute doesn't make that claim.
 - You want every request to use the strongest model, no matter what. You can use `uncommon-route/best`, but the savings will be smaller.
-
----
-
-## FAQ
-
-**Will this hurt quality?**
-
-UncommonRoute doesn't blindly chase the cheapest model. Uncertain or high-risk requests escalate to stronger models, and the held-out SWE-bench Verified result above shows matched task quality on that split.
-
-**Where do my prompts go?**
-
-Routing runs locally. Your prompt is sent to the upstream provider you configure, not to a separate hosted routing service.
-
-**What happens when the router is unsure?**
-
-It falls back conservatively: low-confidence decisions escalate instead of quietly sending complex work to an underpowered model.
-
-**Can I override the routing?**
-
-Yes. Use `auto`, `fast`, or `best`, or configure primary and fallback models for simple / medium / complex requests.
-
-**Can I use my own API keys?**
-
-Yes. You can use Commonstack as a managed upstream or register your own provider keys with BYOK.
-
-**Does feedback train anything?**
-
-Yes. Feedback updates a local model overlay and labeled traces can calibrate runtime confidence. The base model is never overwritten, and you can roll back the overlay.
 
 ---
 
@@ -400,6 +374,52 @@ cd UncommonRoute
 pip install -e ".[dev]"
 python -m pytest tests -v
 ```
+
+---
+
+## FAQ
+
+<details>
+<summary><strong>Will this hurt quality?</strong></summary>
+
+UncommonRoute doesn't blindly chase the cheapest model. Uncertain or high-risk requests escalate to stronger models, and the held-out SWE-bench Verified result above shows matched task quality on that split.
+
+</details>
+
+<details>
+<summary><strong>Where do my prompts go?</strong></summary>
+
+Routing runs locally. Your prompt is sent to the upstream provider you configure, not to a separate hosted routing service.
+
+</details>
+
+<details>
+<summary><strong>What happens when the router is unsure?</strong></summary>
+
+It falls back conservatively: low-confidence decisions escalate instead of quietly sending complex work to an underpowered model.
+
+</details>
+
+<details>
+<summary><strong>Can I override the routing?</strong></summary>
+
+Yes. Use `auto`, `fast`, or `best`, or configure primary and fallback models for simple / medium / complex requests.
+
+</details>
+
+<details>
+<summary><strong>Can I use my own API keys?</strong></summary>
+
+Yes. You can use Commonstack as a managed upstream or register your own provider keys with BYOK.
+
+</details>
+
+<details>
+<summary><strong>Does feedback train anything?</strong></summary>
+
+Yes. Feedback updates a local model overlay and labeled traces can calibrate runtime confidence. The base model is never overwritten, and you can roll back the overlay.
+
+</details>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,15 +23,6 @@ UncommonRoute plugs into Claude Code, Cursor, Codex, and the OpenAI SDK. It runs
 <a href="#benchmark">Benchmark</a> ·
 <a href="#privacy">Privacy</a>
 
-<br><br>
-
-```bash
-pipx install uncommon-route
-uncommon-route init
-```
-
-<br>
-
 | | Opus-only | UncommonRoute | Saved |
 |---|:---:|:---:|:---:|
 | Tasks solved | 74 / 100 | **75 / 100** | Matched |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,11 +4,11 @@
 
 <h1>UncommonRoute</h1>
 
-**任务完成质量不变，API 花费减少一半。**
+**API 花费减半，任务完成质量不打折。**
 
 接入 Claude Code、Cursor、Codex 或 OpenAI SDK。UncommonRoute 在本地运行，把每次请求路由到最合适的模型。
 
-<strong>训练后的路由器：任务通过 75/100，对比全程 Opus 74/100；API 成本下降 53%。</strong>
+<strong>训练后的路由器完成 75/100 个任务，全程 Opus 完成 74/100；API 成本下降 53%。</strong>
 
 <a href="https://pypi.org/project/uncommon-route/"><img src="https://img.shields.io/pypi/v/uncommon-route?style=flat-square&logo=pypi&logoColor=white&label=PyPI" alt="PyPI"></a>
 <a href="https://www.npmjs.com/package/@anjieyang/uncommon-route"><img src="https://img.shields.io/npm/v/@anjieyang/uncommon-route?style=flat-square&logo=npm&logoColor=white&label=npm" alt="npm"></a>
@@ -17,17 +17,17 @@
 
 <br><br>
 
-<a href="#30-秒跑起来">Quickstart</a> ·
+<a href="#30-秒跑起来">30 秒上手</a> ·
 <a href="#uncommonroute-如何帮你省钱">省钱逻辑</a> ·
 <a href="#可视化路由">Dashboard</a> ·
 <a href="#benchmark">Benchmark</a> ·
 <a href="#工作原理">工作原理</a> ·
 <a href="#faq">FAQ</a>
 
-| 全程 Opus | UncommonRoute（训练后） | 省下 |
-|---:|---:|---:|
-| 74 / 100 任务通过 | **75 / 100 任务通过** | 质量持平 |
-| $54.73 API 成本 | **$25.66 API 成本** | **−53%** |
+| | 全程 Opus | UncommonRoute（训练后） | 省下 |
+|---|:---:|:---:|:---:|
+| 任务完成 | 74 / 100 | **75 / 100** | 持平 |
+| API 成本 | $54.73 | **$25.66** | **−53%** |
 
 <sub>数据来自训练后的 UncommonRoute 路由器在 <a href="https://github.com/CommonstackAI/TwinRouterBench">TwinRouterBench</a> 100 个 held-out SWE-bench Verified case 上的结果。说明见下文。</sub>
 
@@ -80,7 +80,7 @@ uncommon-route doctor
 "设计一个分布式调度器"             -> complex
 ```
 
-simple 请求优先走轻量模型，medium 请求走能力和成本更匹配的模型，complex 请求再调用你配置里的最强模型。所有判断都按请求独立完成，不会把整个会话固定在同一个模型上。
+simple 请求优先走轻量模型，medium 请求走能力和成本更匹配的模型，complex 请求才走你配置里的最强模型。所有判断都按请求独立完成，不会把整个会话固定在同一个模型上。
 
 ---
 
@@ -88,7 +88,7 @@ simple 请求优先走轻量模型，medium 请求走能力和成本更匹配的
 
 如果你每天用 AI agent 写代码，很容易遇到一种浪费：改错字、补注释、运行简单测试，也默认调用最贵的模型。
 
-UncommonRoute 的边界很清楚：它不替代 Claude Code、Cursor 或 Codex，也不改变模型本身的能力。它专注于一件事：为每次请求选择最匹配的模型。
+UncommonRoute 只做一件事：它不替代 Claude Code、Cursor 或 Codex，也不改变模型本身的能力；它只负责为每次请求选择最匹配的模型。
 
 > 这个请求，最适合交给哪个模型？
 
@@ -111,9 +111,9 @@ Dashboard 主要解决五件事：
 - 按会话查看每一步路由决策，包括模型、延迟、成本和信号读数。
 - 看清楚哪些复杂度分类、哪些模型真正消耗了预算。
 - 调整路由策略、fallback、预算上限、provider key 和模型池。
-- 把路由结果标成 `too strong` / `just right` / `too weak`；这些标注会训练本地模型覆盖层，不会覆盖基础模型。
+- 把路由结果标成 `too strong` / `just right` / `too weak`；这些标注会训练一个本地适配层，它叠在基础分类器之上，不会改写基础模型。
 
-Feedback 是长期使用里很有价值的一块。如果某次路由太激进或太保守，你可以直接在 Dashboard 里纠正。训练在本地完成，基础模型保持不变，模型覆盖层也可以随时回滚。
+Feedback 是长期使用里很有价值的一块。如果某次路由太激进或太保守，你可以直接在 Dashboard 里纠正。训练在本地完成，基础模型保持不变，本地适配层可以随时回滚。
 
 ---
 
@@ -147,7 +147,7 @@ resp = client.chat.completions.create(
 
 ---
 
-## 为什么选 UncommonRoute
+## 核心亮点
 
 | 能力 | 结果 |
 |---|---|
@@ -157,7 +157,7 @@ resp = client.chat.completions.create(
 | 可解释决策 | 每次路由都能看到复杂度分类、置信度、信号读数、模型和成本 |
 | 可调整策略 | 支持 `auto` / `fast` / `best`，也支持按 simple / medium / complex 配置 override 和 fallback |
 | 预算封顶 | 可以设置请求级、小时级或每日 API 花费上限 |
-| 本地训练 | Feedback 会更新本地模型覆盖层；基础模型不会被覆盖，也可以随时回滚 |
+| 本地训练 | Feedback 会更新本地适配层；基础模型不会被改写，适配层可以随时回滚 |
 | 即插即用 | Claude Code、Cursor、Codex、OpenAI SDK、OpenClaw 都不用改业务代码 |
 
 ---
@@ -169,12 +169,12 @@ resp = client.chat.completions.create(
 | 信号 | 看什么 | 运行说明 |
 |---|---|---:|
 | Metadata | 对话结构、工具调用、上下文深度 | 很轻 |
-| Embedding | 用户请求、最近 agent 状态和元数据上的 BGE 分类器；不确定时退到 KNN | 取决于本地运行时资产和缓存状态 |
+| Embedding | 在用户请求、最近 agent 状态和元数据上运行 BGE 分类器；不确定时退到 KNN | 取决于本地运行时资产和缓存状态 |
 | Structural | 文本复杂度、对话复杂度；只在需要时激活，其余时候 shadow 跟踪 | 很轻 |
 
 三个信号投票后，由 ensemble 决定复杂度分类。Router 再根据分类、能力、transport、upstream 可用性和价格，在匹配的候选里选择成本更低的可用模型。上游价格未知时按保守估计处理。
 
-路由是**按请求 / 按 agent step**做的，不绑定整个会话。协议层限制仍然会遵守，例如 Anthropic thinking continuation 这类场景不会被随意打断。
+路由是**按请求 / 按 agent step**做的，不绑定整个会话。路由器仍然会遵守协议层约束，例如 Anthropic thinking continuation 不会被随意打断。
 
 UncommonRoute 也会从本地反馈里学习：高置信、一致的样本会进入 embedding 索引；低置信预测会向上升档，避免把复杂任务路由到能力不足的模型。
 
@@ -186,16 +186,16 @@ UncommonRoute 在 [TwinRouterBench](https://github.com/CommonstackAI/TwinRouterB
 
 下面的端到端验证使用一组 100 个 held-out SWE-bench Verified case，报告的是论文 Table 3 里的训练后路由器结果。
 
-### 任务通过率持平，API 成本少 53%
+### 任务完成数持平，API 成本少 53%
 
-| 策略 | 任务通过 | API 成本 | vs 全程 Opus |
+| 策略 | 任务完成 | API 成本 | vs 全程 Opus |
 |---|:---:|:---:|:---:|
 | 全程 Opus 4.6 | 74 / 100 | $54.73 | — |
 | **UncommonRoute（训练后）** | **75 / 100** | **$25.66** | **−53%** |
 
-也就是说，不是“少花钱但少做成任务”。在这组任务里，训练后的 UncommonRoute 路由器任务通过数与全程 Opus 持平，实际 API 调用成本下降 53%。
+也就是说，不是“少花钱但少做成任务”。在这组任务里，训练后的 UncommonRoute 路由器任务完成数与全程 Opus 持平，实际 API 调用成本下降 53%。
 
-这里的“任务通过”表示 100 个 held-out SWE-bench Verified case 中成功解决的任务数；“API 成本”表示实际模型调用成本，不包含论文 Table 3 里的 penalty cost。
+这里的“任务完成”表示 100 个 held-out SWE-bench Verified case 中成功解决的任务数；“API 成本”表示实际模型调用成本，不包含论文 Table 3 里的 penalty cost。
 
 ### 复现
 
@@ -208,7 +208,7 @@ python scripts/bench_overhead.py --iterations 50 --json
 
 ### 路由开销
 
-路由开销会受硬件、已安装的运行时资产、实际启用的信号影响。运行上面的命令可以得到当前 checkout 的 cold start，以及热进程下的 p50 / p90 / p99。
+路由开销会受硬件、已安装的运行时资产、实际启用的信号影响。运行上面的命令可以得到当前版本的 cold start，以及热进程下的 p50 / p90 / p99。
 
 ---
 
@@ -404,7 +404,7 @@ UncommonRoute 不是一味追求便宜。不确定或风险高的请求会向更
 <details>
 <summary><strong>Feedback 真的会训练东西吗？</strong></summary>
 
-会。Feedback 会更新本地模型覆盖层，带标注的本地 trace 也可以用于校准运行时置信度。基础模型不会被覆盖，模型覆盖层可以随时回滚。
+会。Feedback 会更新本地适配层，带标注的本地 trace 也可以用于校准运行时置信度。基础模型不会被改写，适配层可以随时回滚。
 
 </details>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,15 +23,6 @@ UncommonRoute 接入 Claude Code、Cursor、Codex 和 OpenAI SDK，本地分析�
 <a href="#benchmark">Benchmark</a> ·
 <a href="#隐私">Privacy</a>
 
-<br><br>
-
-```bash
-pipx install uncommon-route
-uncommon-route init
-```
-
-<br>
-
 | 全程 Opus | UncommonRoute | 省下 |
 |---:|---:|---:|
 | 74 / 100 任务通过 | **75 / 100 任务通过** | 质量持平 |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,9 +6,9 @@
 
 **任务完成质量不变，API 花费减少一半。**
 
-UncommonRoute 接入 Claude Code、Cursor、Codex 和 OpenAI SDK，本地分析任务复杂度、上下文结构、工具调用、可用模型池和预算限制，再把请求路由到最合适的模型。
+接入 Claude Code、Cursor、Codex 或 OpenAI SDK。UncommonRoute 在本地运行，把每次请求路由到最合适的模型。
 
-<strong>在 100 个 held-out SWE-bench Verified 任务上，UncommonRoute 任务通过数 75/100，对比全程 Opus 74/100。任务完成质量不变的同时，API 成本下降 53%。</strong>
+<strong>任务通过 75/100，对比全程 Opus 74/100；API 成本下降 53%。</strong>
 
 <a href="https://pypi.org/project/uncommon-route/"><img src="https://img.shields.io/pypi/v/uncommon-route?style=flat-square&logo=pypi&logoColor=white&label=PyPI" alt="PyPI"></a>
 <a href="https://www.npmjs.com/package/@anjieyang/uncommon-route"><img src="https://img.shields.io/npm/v/@anjieyang/uncommon-route?style=flat-square&logo=npm&logoColor=white&label=npm" alt="npm"></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@
 
 接入 Claude Code、Cursor、Codex 或 OpenAI SDK。UncommonRoute 在本地运行，把每次请求路由到最合适的模型。
 
-<strong>任务通过 75/100，对比全程 Opus 74/100；API 成本下降 53%。</strong>
+<strong>训练后的路由器：任务通过 75/100，对比全程 Opus 74/100；API 成本下降 53%。</strong>
 
 <a href="https://pypi.org/project/uncommon-route/"><img src="https://img.shields.io/pypi/v/uncommon-route?style=flat-square&logo=pypi&logoColor=white&label=PyPI" alt="PyPI"></a>
 <a href="https://www.npmjs.com/package/@anjieyang/uncommon-route"><img src="https://img.shields.io/npm/v/@anjieyang/uncommon-route?style=flat-square&logo=npm&logoColor=white&label=npm" alt="npm"></a>
@@ -24,12 +24,12 @@
 <a href="#工作原理">工作原理</a> ·
 <a href="#faq">FAQ</a>
 
-| 全程 Opus | UncommonRoute | 省下 |
+| 全程 Opus | UncommonRoute（训练后） | 省下 |
 |---:|---:|---:|
 | 74 / 100 任务通过 | **75 / 100 任务通过** | 质量持平 |
 | $54.73 API 成本 | **$25.66 API 成本** | **−53%** |
 
-<sub>数据来自 <a href="https://github.com/CommonstackAI/TwinRouterBench">TwinRouterBench</a> 的 100 个 held-out SWE-bench Verified case。复现命令见下文。</sub>
+<sub>数据来自训练后的 UncommonRoute 路由器在 <a href="https://github.com/CommonstackAI/TwinRouterBench">TwinRouterBench</a> 100 个 held-out SWE-bench Verified case 上的结果。说明见下文。</sub>
 
 </div>
 
@@ -182,25 +182,27 @@ UncommonRoute 也会从本地反馈里学习：高置信、一致的样本会进
 
 ## Benchmark
 
-UncommonRoute 在 [TwinRouterBench](https://github.com/CommonstackAI/TwinRouterBench) 上评测。该评测包含 SWE-Bench、BFCL、mtRAG、QMSum、PinchBench 的 520 个实例，共 970 条路由器可见的任务前缀，并带有执行验证过的目标档位标签。端到端验证使用一组 100 个 held-out SWE-bench Verified case。
+UncommonRoute 在 [TwinRouterBench](https://github.com/CommonstackAI/TwinRouterBench) 上评测。该评测包含 SWE-Bench、BFCL、mtRAG、QMSum、PinchBench 的 520 个实例，共 970 条路由器可见的任务前缀，并带有执行验证过的目标档位标签。TwinRouterBench 使用四个内部档位（`low` / `mid` / `mid_high` / `high`）评分；产品界面里展示为 `simple` / `medium` / `complex`。
+
+下面的端到端验证使用一组 100 个 held-out SWE-bench Verified case，报告的是论文 Table 3 里的训练后路由器结果。
 
 ### 任务通过率持平，API 成本少 53%
 
 | 策略 | 任务通过 | API 成本 | vs 全程 Opus |
 |---|:---:|:---:|:---:|
 | 全程 Opus 4.6 | 74 / 100 | $54.73 | — |
-| **UncommonRoute** | **75 / 100** | **$25.66** | **−53%** |
+| **UncommonRoute（训练后）** | **75 / 100** | **$25.66** | **−53%** |
 
-也就是说，不是“少花钱但少做成任务”。在这组任务里，UncommonRoute 的任务通过数与全程 Opus 持平，实际 API 调用成本下降 53%。
+也就是说，不是“少花钱但少做成任务”。在这组任务里，训练后的 UncommonRoute 路由器任务通过数与全程 Opus 持平，实际 API 调用成本下降 53%。
 
 这里的“任务通过”表示 100 个 held-out SWE-bench Verified case 中成功解决的任务数；“API 成本”表示实际模型调用成本，不包含论文 Table 3 里的 penalty cost。
 
 ### 复现
 
+完整复现 Table 3 需要 TwinRouterBench 的发布包，因为它依赖锁定的 dynamic split、模型池、价格文件和 scorer。这个 repo 提供本地路由器本身，以及路由开销检查：
+
 ```bash
 python -m pip install -e ".[dev]"
-python -m pip install "git+https://github.com/CommonstackAI/TwinRouterBench.git"
-python scripts/eval_v2.py --split holdout
 python scripts/bench_overhead.py --iterations 50 --json
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -162,6 +162,24 @@ resp = client.chat.completions.create(
 
 ---
 
+## 工作原理
+
+每个请求会经过三个本地 signal，先判断任务复杂度，再从你配置的 upstream 里选择最匹配的模型。
+
+| Signal | 看什么 | 典型开销 |
+|---|---|---:|
+| Metadata | 对话结构、工具调用、上下文深度 | <1ms |
+| Embedding | 用户请求、最近 agent 状态和元数据上的 BGE 分类器；不确定时退到 KNN | ~25–35ms |
+| Structural | 文本复杂度、对话复杂度；只在需要时激活，其余时候 shadow 跟踪 | <1ms |
+
+三个 signal 投票后，由 ensemble 决定复杂度分类。Router 再根据分类、能力、transport、upstream 可用性和价格，在匹配的候选里选择成本更低的可用模型。上游价格未知时按保守估计处理。
+
+路由是**按请求 / 按 agent step**做的，不绑定整个会话。协议层限制仍然会遵守，例如 Anthropic thinking continuation 这类场景不会被随意打断。
+
+UncommonRoute 也会从本地反馈里学习：高置信、一致的样本会进入 embedding 索引；低置信预测会向上升档，避免把复杂任务路由到能力不足的模型。
+
+---
+
 ## Benchmark
 
 UncommonRoute 在 [TwinRouterBench](https://github.com/CommonstackAI/TwinRouterBench) 上评测。该评测包含 SWE-Bench、BFCL、mtRAG、QMSum、PinchBench 的 520 个实例，共 970 条路由器可见的任务前缀，并带有执行验证过的目标档位标签。端到端验证使用一组 100 个 held-out SWE-bench Verified case。
@@ -199,39 +217,13 @@ python scripts/bench_overhead.py --iterations 50 --json
 
 ---
 
-## 工作原理
+## 适合谁
 
-每个请求会经过三个本地 signal，先判断任务复杂度，再从你配置的 upstream 里选择最匹配的模型。
-
-| Signal | 看什么 | 典型开销 |
-|---|---|---:|
-| Metadata | 对话结构、工具调用、上下文深度 | <1ms |
-| Embedding | 用户请求、最近 agent 状态和元数据上的 BGE 分类器；不确定时退到 KNN | ~25–35ms |
-| Structural | 文本复杂度、对话复杂度；只在需要时激活，其余时候 shadow 跟踪 | <1ms |
-
-三个 signal 投票后，由 ensemble 决定复杂度分类。Router 再根据分类、能力、transport、upstream 可用性和价格，在匹配的候选里选择成本更低的可用模型。上游价格未知时按保守估计处理。
-
-路由是**按请求 / 按 agent step**做的，不绑定整个会话。协议层限制仍然会遵守，例如 Anthropic thinking continuation 这类场景不会被随意打断。
-
-UncommonRoute 也会从本地反馈里学习：高置信、一致的样本会进入 embedding 索引；低置信预测会向上升档，避免把复杂任务路由到能力不足的模型。
-
----
-
-## 隐私
-
-路由在本地完成。**prompt 不会经过额外的云端路由器；它只会发给你配置的 upstream provider。**
-
-```bash
-uncommon-route telemetry status
-```
-
-诊断文件也默认保存在本机：
-
-```bash
-uncommon-route support bundle
-```
-
-脱敏后的 support bundle 会写到 `~/.uncommon-route/support/`。只有你主动分享时，它才会离开本机。
+- 你每天都在用 Claude Code、Cursor、Codex 或类似 agent 写代码。
+- 你的账单主要花在最强模型上，但很多请求并不需要同一档模型。
+- 你想省 API 成本，但不想把 prompt 发给一个额外的云端路由器。
+- 你需要按请求粒度路由，而不是整个会话只选一次模型。
+- 你希望有可解释、可调整、可反馈的路由，而不只是一个黑盒代理。
 
 ---
 
@@ -245,24 +237,6 @@ uncommon-route spend status
 ```
 
 Dashboard 里也可以设置请求级、小时级或每日预算。达到上限后，请求会回退到当前可用的最低成本档位，而不是直接失败。
-
----
-
-## 适合谁
-
-- 你每天都在用 Claude Code、Cursor、Codex 或类似 agent 写代码。
-- 你的账单主要花在最强模型上，但很多请求并不需要同一档模型。
-- 你想省 API 成本，但不想把 prompt 发给一个额外的云端路由器。
-- 你需要按请求粒度路由，而不是整个会话只选一次模型。
-- 你希望有可解释、可调整、可反馈的路由，而不只是一个黑盒代理。
-
----
-
-## 不适合谁
-
-- 你只偶尔调用 LLM，账单本来就很低。
-- 你希望路由器提升低成本模型本身的能力。UncommonRoute 不做这个承诺。
-- 你所有任务都必须无条件使用最强模型。那可以直接用 `uncommon-route/best`，但省钱空间会小很多。
 
 ---
 
@@ -317,6 +291,24 @@ uncommon-route provider remove <name>
 | `UNCOMMON_ROUTE_PORT` | 本地 proxy 端口，默认 8403 |
 
 </details>
+
+---
+
+## 隐私
+
+路由在本地完成。**prompt 不会经过额外的云端路由器；它只会发给你配置的 upstream provider。**
+
+```bash
+uncommon-route telemetry status
+```
+
+诊断文件也默认保存在本机：
+
+```bash
+uncommon-route support bundle
+```
+
+脱敏后的 support bundle 会写到 `~/.uncommon-route/support/`。只有你主动分享时，它才会离开本机。
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,10 +19,10 @@ UncommonRoute 接入 Claude Code、Cursor、Codex 和 OpenAI SDK，本地分析�
 
 <a href="#30-秒跑起来">Quickstart</a> ·
 <a href="#uncommonroute-如何帮你省钱">省钱逻辑</a> ·
-<a href="#为什么需要-uncommonroute">为什么需要</a> ·
 <a href="#可视化路由">Dashboard</a> ·
 <a href="#benchmark">Benchmark</a> ·
-<a href="#隐私">Privacy</a>
+<a href="#工作原理">工作原理</a> ·
+<a href="#faq">FAQ</a>
 
 | 全程 Opus | UncommonRoute | 省下 |
 |---:|---:|---:|
@@ -199,6 +199,24 @@ python scripts/bench_overhead.py --iterations 50 --json
 
 ---
 
+## 工作原理
+
+每个请求会经过三个本地 signal，先判断任务复杂度，再从你配置的 upstream 里选择最匹配的模型。
+
+| Signal | 看什么 | 典型开销 |
+|---|---|---:|
+| Metadata | 对话结构、工具调用、上下文深度 | <1ms |
+| Embedding | 用户请求、最近 agent 状态和元数据上的 BGE 分类器；不确定时退到 KNN | ~25–35ms |
+| Structural | 文本复杂度、对话复杂度；只在需要时激活，其余时候 shadow 跟踪 | <1ms |
+
+三个 signal 投票后，由 ensemble 决定复杂度分类。Router 再根据分类、能力、transport、upstream 可用性和价格，在匹配的候选里选择成本更低的可用模型。上游价格未知时按保守估计处理。
+
+路由是**按请求 / 按 agent step**做的，不绑定整个会话。协议层限制仍然会遵守，例如 Anthropic thinking continuation 这类场景不会被随意打断。
+
+UncommonRoute 也会从本地反馈里学习：高置信、一致的样本会进入 embedding 索引；低置信预测会向上升档，避免把复杂任务路由到能力不足的模型。
+
+---
+
 ## 隐私
 
 路由在本地完成。**prompt 不会经过额外的云端路由器；它只会发给你配置的 upstream provider。**
@@ -230,24 +248,6 @@ Dashboard 里也可以设置请求级、小时级或每日预算。达到上限�
 
 ---
 
-## 工作原理
-
-每个请求会经过三个本地 signal，先判断任务复杂度，再从你配置的 upstream 里选择最匹配的模型。
-
-| Signal | 看什么 | 典型开销 |
-|---|---|---:|
-| Metadata | 对话结构、工具调用、上下文深度 | <1ms |
-| Embedding | 用户请求、最近 agent 状态和元数据上的 BGE 分类器；不确定时退到 KNN | ~25–35ms |
-| Structural | 文本复杂度、对话复杂度；只在需要时激活，其余时候 shadow 跟踪 | <1ms |
-
-三个 signal 投票后，由 ensemble 决定复杂度分类。Router 再根据分类、能力、transport、upstream 可用性和价格，在匹配的候选里选择成本更低的可用模型。上游价格未知时按保守估计处理。
-
-路由是**按请求 / 按 agent step**做的，不绑定整个会话。协议层限制仍然会遵守，例如 Anthropic thinking continuation 这类场景不会被随意打断。
-
-UncommonRoute 也会从本地反馈里学习：高置信、一致的样本会进入 embedding 索引；低置信预测会向上升档，避免把复杂任务路由到能力不足的模型。
-
----
-
 ## 适合谁
 
 - 你每天都在用 Claude Code、Cursor、Codex 或类似 agent 写代码。
@@ -256,39 +256,13 @@ UncommonRoute 也会从本地反馈里学习：高置信、一致的样本会进
 - 你需要按请求粒度路由，而不是整个会话只选一次模型。
 - 你希望有可解释、可调整、可反馈的路由，而不只是一个黑盒代理。
 
+---
+
 ## 不适合谁
 
 - 你只偶尔调用 LLM，账单本来就很低。
 - 你希望路由器提升低成本模型本身的能力。UncommonRoute 不做这个承诺。
 - 你所有任务都必须无条件使用最强模型。那可以直接用 `uncommon-route/best`，但省钱空间会小很多。
-
----
-
-## FAQ
-
-**会影响任务质量吗？**
-
-UncommonRoute 不是一味追求便宜。不确定或风险高的请求会向更强模型升档，上面的 held-out SWE-bench Verified 结果也显示，在那组任务上任务完成质量持平。
-
-**我的 prompt 会发到哪里？**
-
-路由在本地完成。prompt 会发给你配置的 upstream provider，不会额外经过一个托管的云端路由服务。
-
-**路由器不确定时怎么办？**
-
-默认保守处理：低置信度请求会升档，而不是悄悄把复杂任务发给能力不足的模型。
-
-**我可以手动覆盖路由吗？**
-
-可以。你可以用 `auto`、`fast`、`best`，也可以按 simple / medium / complex 配置 primary 和 fallback model。
-
-**可以用自己的 API key 吗？**
-
-可以。你可以用 Commonstack 托管 upstream，也可以用 BYOK 注册自己的 provider key。
-
-**Feedback 真的会训练东西吗？**
-
-会。Feedback 会更新本地模型覆盖层，带标注的本地 trace 也可以用于校准运行时置信度。基础模型不会被覆盖，模型覆盖层可以随时回滚。
 
 ---
 
@@ -400,6 +374,52 @@ cd UncommonRoute
 pip install -e ".[dev]"
 python -m pytest tests -v
 ```
+
+---
+
+## FAQ
+
+<details>
+<summary><strong>会影响任务质量吗？</strong></summary>
+
+UncommonRoute 不是一味追求便宜。不确定或风险高的请求会向更强模型升档，上面的 held-out SWE-bench Verified 结果也显示，在那组任务上任务完成质量持平。
+
+</details>
+
+<details>
+<summary><strong>我的 prompt 会发到哪里？</strong></summary>
+
+路由在本地完成。prompt 会发给你配置的 upstream provider，不会额外经过一个托管的云端路由服务。
+
+</details>
+
+<details>
+<summary><strong>路由器不确定时怎么办？</strong></summary>
+
+默认保守处理：低置信度请求会升档，而不是悄悄把复杂任务发给能力不足的模型。
+
+</details>
+
+<details>
+<summary><strong>我可以手动覆盖路由吗？</strong></summary>
+
+可以。你可以用 `auto`、`fast`、`best`，也可以按 simple / medium / complex 配置 primary 和 fallback model。
+
+</details>
+
+<details>
+<summary><strong>可以用自己的 API key 吗？</strong></summary>
+
+可以。你可以用 Commonstack 托管 upstream，也可以用 BYOK 注册自己的 provider key。
+
+</details>
+
+<details>
+<summary><strong>Feedback 真的会训练东西吗？</strong></summary>
+
+会。Feedback 会更新本地模型覆盖层，带标注的本地 trace 也可以用于校准运行时置信度。基础模型不会被覆盖，模型覆盖层可以随时回滚。
+
+</details>
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,8 +18,9 @@ UncommonRoute 接入 Claude Code、Cursor、Codex 和 OpenAI SDK，本地分析�
 <br><br>
 
 <a href="#30-秒跑起来">Quickstart</a> ·
+<a href="#uncommonroute-如何帮你省钱">省钱逻辑</a> ·
+<a href="#为什么需要-uncommonroute">为什么需要</a> ·
 <a href="#可视化路由">Dashboard</a> ·
-<a href="#支持哪些客户端">Clients</a> ·
 <a href="#benchmark">Benchmark</a> ·
 <a href="#隐私">Privacy</a>
 
@@ -64,6 +65,34 @@ uncommon-route doctor
 - **指定 Python 版本**：`pipx install --python python3.12 uncommon-route`
 
 </details>
+
+---
+
+## UncommonRoute 如何帮你省钱
+
+省钱不是靠少用 AI，而是避免把简单请求默认交给最强模型。
+
+```text
+"hello"                         -> simple
+"修一下 README 里的错字"          -> simple
+"定位这个失败测试并修复"            -> medium
+"重构这个 500 行模块"             -> medium / complex
+"设计一个分布式调度器"             -> complex
+```
+
+simple 请求优先走轻量模型，medium 请求走能力和成本更匹配的模型，complex 请求再调用你配置里的最强模型。所有判断都按请求独立完成，不会把整个会话固定在同一个模型上。
+
+---
+
+## 为什么需要 UncommonRoute
+
+如果你每天用 AI agent 写代码，很容易遇到一种浪费：改错字、补注释、运行简单测试，也默认调用最贵的模型。
+
+UncommonRoute 的边界很清楚：它不替代 Claude Code、Cursor 或 Codex，也不改变模型本身的能力。它专注于一件事：为每次请求选择最匹配的模型。
+
+> 这个请求，最适合交给哪个模型？
+
+路由在本地完成，请求按 agent step 独立判断，不会把整个会话固定在同一个复杂度分类或模型档位上。你也可以在 Dashboard 里看到每一步决策，而不是只能相信一个黑盒结果。
 
 ---
 
@@ -119,34 +148,6 @@ resp = client.chat.completions.create(
     messages=msgs,
 )
 ```
-
----
-
-## UncommonRoute 如何帮你省钱
-
-省钱不是靠少用 AI，而是避免把简单请求默认交给最强模型。
-
-```text
-"hello"                         -> simple
-"修一下 README 里的错字"          -> simple
-"定位这个失败测试并修复"            -> medium
-"重构这个 500 行模块"             -> medium / complex
-"设计一个分布式调度器"             -> complex
-```
-
-simple 请求优先走轻量模型，medium 请求走能力和成本更匹配的模型，complex 请求再调用你配置里的最强模型。所有判断都按请求独立完成，不会把整个会话固定在同一个模型上。
-
----
-
-## 为什么需要 UncommonRoute
-
-如果你每天用 AI agent 写代码，很容易遇到一种浪费：改错字、补注释、运行简单测试，也默认调用最贵的模型。
-
-UncommonRoute 的边界很清楚：它不替代 Claude Code、Cursor 或 Codex，也不改变模型本身的能力。它专注于一件事：为每次请求选择最匹配的模型。
-
-> 这个请求，最适合交给哪个模型？
-
-路由在本地完成，请求按 agent step 独立判断，不会把整个会话固定在同一个复杂度分类或模型档位上。你也可以在 Dashboard 里看到每一步决策，而不是只能相信一个黑盒结果。
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -164,15 +164,15 @@ resp = client.chat.completions.create(
 
 ## 工作原理
 
-每个请求会经过三个本地 signal，先判断任务复杂度，再从你配置的 upstream 里选择最匹配的模型。
+每个请求会经过三个本地信号，先判断任务复杂度，再从你配置的 upstream 里选择最匹配的模型。
 
-| Signal | 看什么 | 典型开销 |
+| 信号 | 看什么 | 运行说明 |
 |---|---|---:|
-| Metadata | 对话结构、工具调用、上下文深度 | <1ms |
-| Embedding | 用户请求、最近 agent 状态和元数据上的 BGE 分类器；不确定时退到 KNN | ~25–35ms |
-| Structural | 文本复杂度、对话复杂度；只在需要时激活，其余时候 shadow 跟踪 | <1ms |
+| Metadata | 对话结构、工具调用、上下文深度 | 很轻 |
+| Embedding | 用户请求、最近 agent 状态和元数据上的 BGE 分类器；不确定时退到 KNN | 取决于本地运行时资产和缓存状态 |
+| Structural | 文本复杂度、对话复杂度；只在需要时激活，其余时候 shadow 跟踪 | 很轻 |
 
-三个 signal 投票后，由 ensemble 决定复杂度分类。Router 再根据分类、能力、transport、upstream 可用性和价格，在匹配的候选里选择成本更低的可用模型。上游价格未知时按保守估计处理。
+三个信号投票后，由 ensemble 决定复杂度分类。Router 再根据分类、能力、transport、upstream 可用性和价格，在匹配的候选里选择成本更低的可用模型。上游价格未知时按保守估计处理。
 
 路由是**按请求 / 按 agent step**做的，不绑定整个会话。协议层限制仍然会遵守，例如 Anthropic thinking continuation 这类场景不会被随意打断。
 
@@ -193,7 +193,7 @@ UncommonRoute 在 [TwinRouterBench](https://github.com/CommonstackAI/TwinRouterB
 
 也就是说，不是“少花钱但少做成任务”。在这组任务里，UncommonRoute 的任务通过数与全程 Opus 持平，实际 API 调用成本下降 53%。
 
-这里的“任务通过”表示 100 个 held-out SWE-bench Verified case 中成功解决的任务数；“API 成本”表示实际模型调用成本，不包含 Table 4 里的 penalty cost。
+这里的“任务通过”表示 100 个 held-out SWE-bench Verified case 中成功解决的任务数；“API 成本”表示实际模型调用成本，不包含论文 Table 3 里的 penalty cost。
 
 ### 复现
 
@@ -206,14 +206,7 @@ python scripts/bench_overhead.py --iterations 50 --json
 
 ### 路由开销
 
-本地 CPU，热进程：
-
-| 指标 | 延迟 |
-|---|:---:|
-| p50 | 25.6ms |
-| p90 | 32.1ms |
-
-冷启动需要加载 embedding 模型，可能要几秒；进程预热后，单次 `route()` 通常是几十毫秒。
+路由开销会受硬件、已安装的运行时资产、实际启用的信号影响。运行上面的命令可以得到当前 checkout 的 cold start，以及热进程下的 p50 / p90 / p99。
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -98,26 +98,22 @@ UncommonRoute 的边界很清楚：它不替代 Claude Code、Cursor 或 Codex�
 
 ## 可视化路由
 
-UncommonRoute 不只是转发请求的代理。Dashboard 会记录并展示每次路由决策：请求被判定为 simple、medium 还是 complex，最终选择哪个模型，预计或实际成本是多少，以及后续可以如何调整策略。
+UncommonRoute 不只是转发请求的代理。Dashboard 会记录并解释每次路由决策：请求被判定为 simple、medium 还是 complex，最终选择哪个模型，实际花了多少钱，以及后续可以怎么调。
 
 ```bash
 uncommon-route serve
 # -> http://localhost:8403/dashboard/
 ```
 
-| 页面 | 功能 |
-|---|---|
-| Home | 实时请求、复杂度分布、模型选择、成本变化 |
-| Playground | 输入 prompt，预览复杂度分类、置信度、成本估算和信号读数 |
-| Explain | 按会话查看每一步路由决策、模型、延迟和成本 |
-| Activity | 请求复杂度、服务档位、传输路径、能力通道、模型使用和成本分布 |
-| Routing | 配置 `auto` / `fast` / `best`，也可以按复杂度档位指定 primary / fallback model |
-| Models | 查看当前模型池、provider、能力标签和输入 / 输出价格 |
-| Connections | 管理托管 upstream 或 BYOK provider key，并验证连接状态 |
-| Budget | 设置请求级、小时级或每日预算上限 |
-| Feedback | 标记路由 `too strong` / `just right` / `too weak`，用本地反馈改进分类器 |
+Dashboard 主要解决五件事：
 
-推荐的演示路径是：先在 Playground 输入一个 prompt，看路由器给出的复杂度分类、置信度和成本估算；再到 Explain / Activity 里查看真实请求的路由轨迹。
+- 发送前预览 prompt 会被判定为 simple / medium / complex。
+- 按会话查看每一步路由决策，包括模型、延迟、成本和信号读数。
+- 看清楚哪些复杂度分类、哪些模型真正消耗了预算。
+- 调整路由策略、fallback、预算上限、provider key 和模型池。
+- 把路由结果标成 `too strong` / `just right` / `too weak`；这些标注会训练本地模型覆盖层，不会覆盖基础模型。
+
+Feedback 是长期使用里很有价值的一块。如果某次路由太激进或太保守，你可以直接在 Dashboard 里纠正。训练在本地完成，基础模型保持不变，模型覆盖层也可以随时回滚。
 
 ---
 
@@ -155,13 +151,13 @@ resp = client.chat.completions.create(
 
 | 能力 | 结果 |
 |---|---|
-| 本地路由 | prompt、completion 和路由决策不需要发送给额外的云端路由器 |
+| 本地路由 | 路由器在本地运行，不会在你和 provider 之间额外插入一个云端路由服务 |
 | 按请求路由 | 每个 agent step 独立判断，不把整个会话固定在同一个复杂度分类或模型档位上 |
 | 自动选择模型 | 根据任务难度、上下文结构、工具调用和 provider 可用性选择路由结果 |
 | 可解释决策 | 每次路由都能看到复杂度分类、置信度、信号读数、模型和成本 |
 | 可调整策略 | 支持 `auto` / `fast` / `best`，也支持按 simple / medium / complex 配置 override 和 fallback |
 | 预算封顶 | 可以设置请求级、小时级或每日 API 花费上限 |
-| 本地反馈 | 标记路由太强、刚好或太弱，用本地反馈改进分类器 |
+| 本地训练 | Feedback 会更新本地模型覆盖层；基础模型不会被覆盖，也可以随时回滚 |
 | 即插即用 | Claude Code、Cursor、Codex、OpenAI SDK、OpenClaw 都不用改业务代码 |
 
 ---
@@ -205,7 +201,7 @@ python scripts/bench_overhead.py --iterations 50 --json
 
 ## 隐私
 
-路由在本机完成。**prompt、completion 和路由决策都不会为了路由发送给额外服务。**
+路由在本地完成。**prompt 不会经过额外的云端路由器；它只会发给你配置的 upstream provider。**
 
 ```bash
 uncommon-route telemetry status
@@ -265,6 +261,34 @@ UncommonRoute 也会从本地反馈里学习：高置信、一致的样本会进
 - 你只偶尔调用 LLM，账单本来就很低。
 - 你希望路由器提升低成本模型本身的能力。UncommonRoute 不做这个承诺。
 - 你所有任务都必须无条件使用最强模型。那可以直接用 `uncommon-route/best`，但省钱空间会小很多。
+
+---
+
+## FAQ
+
+**会影响任务质量吗？**
+
+UncommonRoute 不是一味追求便宜。不确定或风险高的请求会向更强模型升档，上面的 held-out SWE-bench Verified 结果也显示，在那组任务上任务完成质量持平。
+
+**我的 prompt 会发到哪里？**
+
+路由在本地完成。prompt 会发给你配置的 upstream provider，不会额外经过一个托管的云端路由服务。
+
+**路由器不确定时怎么办？**
+
+默认保守处理：低置信度请求会升档，而不是悄悄把复杂任务发给能力不足的模型。
+
+**我可以手动覆盖路由吗？**
+
+可以。你可以用 `auto`、`fast`、`best`，也可以按 simple / medium / complex 配置 primary 和 fallback model。
+
+**可以用自己的 API key 吗？**
+
+可以。你可以用 Commonstack 托管 upstream，也可以用 BYOK 注册自己的 provider key。
+
+**Feedback 真的会训练东西吗？**
+
+会。Feedback 会更新本地模型覆盖层，带标注的本地 trace 也可以用于校准运行时置信度。基础模型不会被覆盖，模型覆盖层可以随时回滚。
 
 ---
 


### PR DESCRIPTION
## Summary

This PR replaces the README copy with a launch-ready English and Simplified Chinese version.

- Reworks the hero, quick start, savings explanation, dashboard section, supported clients, benchmark, privacy, diagnostics, FAQ, and uninstall flow.
- Keeps benchmark claims aligned with the latest TwinRouterBench paper: Table 3, trained-router result, 75/100 vs 74/100, and 53% lower realized API cost.
- Removes stale routing-overhead numbers and points readers to the local overhead check instead.
- Synchronizes README.md and README.zh-CN.md, including native Chinese wording and consistent benchmark terminology.

## Validation

- Ran markdown consistency checks for heading counts, code fences, FAQ details, and stale benchmark references.
- Ran `git diff --check`.
- Ran `python3 scripts/bench_overhead.py --iterations 5 --json`.

## Notes

Full Table 3 reproduction lives in the TwinRouterBench release package because it requires the locked dynamic split, model pool, pricing files, and scorer. This repo keeps the local router and local overhead check.