### PR TITLE
Refresh MiniMax provider defaults for M3 and M2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,23 @@ uncommon-route provider add google     AIza...
 uncommon-route serve
 ```
 
+MiniMax uses the global OpenAI-compatible endpoint by default. Pass the China
+endpoint explicitly when needed:
+
+```bash
+uncommon-route provider add minimax eyJ-...
+uncommon-route provider add minimax eyJ-... --url https://api.minimaxi.com/v1
+```
+
+| Region | OpenAI-compatible base URL | Anthropic-compatible base URL |
+|---|---|---|
+| Global | `https://api.minimax.io/v1` | `https://api.minimax.io/anthropic` |
+| China | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic` |
+
+Provider configuration stores the OpenAI-compatible base URL. Anthropic
+requests use the corresponding `/anthropic` base and append `/v1/messages`
+internally.
+
 > UncommonRoute doesn't automatically read `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`. Use `init`, a saved connection, or one of the manual setup paths above.
 
 ### Routing Modes

--- a/tests/test_anthropic_compat.py
+++ b/tests/test_anthropic_compat.py
@@ -1956,7 +1956,7 @@ class TestTransportRouting:
                     "id": "msg_minimax_byok",
                     "type": "message",
                     "role": "assistant",
-                    "model": "minimax/minimax-m3",
+                    "model": "MiniMax-M3",
                     "content": [{"type": "text", "text": "ok"}],
                     "stop_reason": "end_turn",
                     "stop_sequence": None,
@@ -1993,6 +1993,9 @@ class TestTransportRouting:
             headers = captured["headers"]
             assert isinstance(headers, dict)
             assert headers["x-api-key"] == "mm-key-123"
+            body = captured["body"]
+            assert isinstance(body, dict)
+            assert body["model"] == "MiniMax-M3"
         finally:
             asyncio.run(async_client.aclose())
 
@@ -2021,7 +2024,7 @@ class TestTransportRouting:
                     "id": "chatcmpl_minimax",
                     "object": "chat.completion",
                     "created": 1,
-                    "model": "minimax/minimax-m3",
+                    "model": "MiniMax-M3",
                     "choices": [{
                         "index": 0,
                         "message": {"role": "assistant", "content": "done"},
@@ -2065,7 +2068,7 @@ class TestTransportRouting:
             assert headers["authorization"] == "Bearer mm-key-123"
             body = captured["body"]
             assert isinstance(body, dict)
-            assert body["model"] == "minimax/minimax-m3"
+            assert body["model"] == "MiniMax-M3"
         finally:
             asyncio.run(async_client.aclose())
 

--- a/tests/test_anthropic_compat.py
+++ b/tests/test_anthropic_compat.py
@@ -1931,9 +1931,18 @@ class TestTransportRouting:
         finally:
             asyncio.run(async_client.aclose())
 
+    @pytest.mark.parametrize(
+        ("base_url", "expected_url"),
+        [
+            ("https://api.minimax.io/v1", "https://api.minimax.io/anthropic/v1/messages"),
+            ("https://api.minimaxi.com/v1", "https://api.minimaxi.com/anthropic/v1/messages"),
+        ],
+    )
     def test_messages_use_minimax_anthropic_endpoint_for_direct_provider(
         self,
         monkeypatch: pytest.MonkeyPatch,
+        base_url: str,
+        expected_url: str,
     ) -> None:
         captured: dict[str, object] = {}
 
@@ -1947,7 +1956,7 @@ class TestTransportRouting:
                     "id": "msg_minimax_byok",
                     "type": "message",
                     "role": "assistant",
-                    "model": "minimax/minimax-m2.1",
+                    "model": "minimax/minimax-m3",
                     "content": [{"type": "text", "text": "ok"}],
                     "stop_reason": "end_turn",
                     "stop_sequence": None,
@@ -1964,32 +1973,41 @@ class TestTransportRouting:
                 "minimax": ProviderEntry(
                     name="minimax",
                     api_key="mm-key-123",
-                    base_url="https://api.minimax.io/v1",
-                    models=["minimax/minimax-m2.1"],
+                    base_url=base_url,
+                    models=["minimax/minimax-m3"],
                 ),
             })
             app = create_app(
-                upstream="https://api.commonstack.ai/v1",
+                upstream="https://primary.example/v1",
                 providers_config=providers,
             )
             client = TestClient(app, raise_server_exceptions=False)
             resp = client.post("/v1/messages", json={
-                "model": "minimax/minimax-m2.1",
+                "model": "minimax/minimax-m3",
                 "max_tokens": 32,
                 "messages": [{"role": "user", "content": "hello"}],
             })
 
             assert resp.status_code == 200
-            assert captured["url"] == "https://api.minimax.io/anthropic/v1/messages"
+            assert captured["url"] == expected_url
             headers = captured["headers"]
             assert isinstance(headers, dict)
             assert headers["x-api-key"] == "mm-key-123"
         finally:
             asyncio.run(async_client.aclose())
 
-    def test_chat_completions_keep_openai_transport_for_minimax_models(
+    @pytest.mark.parametrize(
+        ("base_url", "expected_url"),
+        [
+            ("https://api.minimax.io/v1", "https://api.minimax.io/v1/chat/completions"),
+            ("https://api.minimaxi.com/v1", "https://api.minimaxi.com/v1/chat/completions"),
+        ],
+    )
+    def test_chat_completions_use_minimax_openai_endpoint_for_direct_provider(
         self,
         monkeypatch: pytest.MonkeyPatch,
+        base_url: str,
+        expected_url: str,
     ) -> None:
         captured: dict[str, object] = {}
 
@@ -2003,7 +2021,7 @@ class TestTransportRouting:
                     "id": "chatcmpl_minimax",
                     "object": "chat.completion",
                     "created": 1,
-                    "model": "minimax/minimax-m2.1",
+                    "model": "minimax/minimax-m3",
                     "choices": [{
                         "index": 0,
                         "message": {"role": "assistant", "content": "done"},
@@ -2016,13 +2034,23 @@ class TestTransportRouting:
 
         async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
         monkeypatch.setattr("uncommon_route.proxy._get_client", lambda: async_client)
-        monkeypatch.setenv("UNCOMMON_ROUTE_API_KEY", "env-key-123")
 
         try:
-            app = create_app(upstream="https://api.commonstack.ai/v1")
+            providers = ProvidersConfig(providers={
+                "minimax": ProviderEntry(
+                    name="minimax",
+                    api_key="mm-key-123",
+                    base_url=base_url,
+                    models=["minimax/minimax-m3"],
+                ),
+            })
+            app = create_app(
+                upstream="https://primary.example/v1",
+                providers_config=providers,
+            )
             client = TestClient(app, raise_server_exceptions=False)
             resp = client.post("/v1/chat/completions", json={
-                "model": "minimax/minimax-m2.1",
+                "model": "minimax/minimax-m3",
                 "max_tokens": 32,
                 "messages": [{"role": "user", "content": "hello"}],
             })
@@ -2031,10 +2059,13 @@ class TestTransportRouting:
             assert resp.headers["x-uncommon-route-requested-transport"] == "openai-chat"
             assert resp.headers["x-uncommon-route-transport"] == "openai-chat"
             assert resp.headers["x-uncommon-route-transport-source"] == "ingress-policy"
-            assert captured["url"] == "https://api.commonstack.ai/v1/chat/completions"
+            assert captured["url"] == expected_url
+            headers = captured["headers"]
+            assert isinstance(headers, dict)
+            assert headers["authorization"] == "Bearer mm-key-123"
             body = captured["body"]
             assert isinstance(body, dict)
-            assert body["model"] == "minimax/minimax-m2.1"
+            assert body["model"] == "minimax/minimax-m3"
         finally:
             asyncio.run(async_client.aclose())
 

--- a/tests/test_cache_support.py
+++ b/tests/test_cache_support.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import json
 
-from uncommon_route.cache_support import apply_anthropic_cache_breakpoints, parse_stream_usage_metrics
-from uncommon_route.router.types import ModelPricing
+from uncommon_route.cache_support import apply_anthropic_cache_breakpoints, estimate_usage_cost, parse_stream_usage_metrics
+from uncommon_route.router.types import ModelPricing, ModelPricingTier
 
 
 def test_anthropic_cache_breakpoints_do_not_upgrade_after_existing_5m() -> None:
@@ -88,3 +88,24 @@ def test_stream_usage_falls_back_to_reasoning_content_tokens_when_usage_missing(
     assert usage.output_tokens > 0
     assert usage.total_tokens == usage.output_tokens
     assert usage.actual_cost is not None
+
+
+def test_usage_cost_applies_long_context_pricing_tier() -> None:
+    pricing = ModelPricing(
+        0.30,
+        1.20,
+        pricing_tiers=(
+            ModelPricingTier("standard", 0.30, 1.20, input_tokens_lte=512_000),
+            ModelPricingTier("standard", 0.60, 2.40, input_tokens_gt=512_000),
+        ),
+    )
+
+    cost = estimate_usage_cost(
+        input_tokens_uncached=600_000,
+        output_tokens=100_000,
+        cache_read_input_tokens=0,
+        cache_write_input_tokens=0,
+        pricing=pricing,
+    )
+
+    assert cost == 0.60

--- a/tests/test_cache_support.py
+++ b/tests/test_cache_support.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 import json
 
-from uncommon_route.cache_support import apply_anthropic_cache_breakpoints, estimate_usage_cost, parse_stream_usage_metrics
+import pytest
+
+from uncommon_route.cache_support import (
+    apply_anthropic_cache_breakpoints,
+    estimate_usage_cost,
+    parse_stream_usage_metrics,
+    parse_usage_metrics,
+)
 from uncommon_route.router.types import ModelPricing, ModelPricingTier
 
 
@@ -109,3 +116,53 @@ def test_usage_cost_applies_long_context_pricing_tier() -> None:
     )
 
     assert cost == 0.60
+
+
+def test_usage_cost_applies_priority_pricing_tier() -> None:
+    pricing = ModelPricing(
+        0.30,
+        1.20,
+        pricing_tiers=(
+            ModelPricingTier("standard", 0.60, 2.40, input_tokens_gt=512_000),
+            ModelPricingTier("priority", 0.90, 3.60, input_tokens_gt=512_000),
+        ),
+    )
+
+    cost = estimate_usage_cost(
+        input_tokens_uncached=600_000,
+        output_tokens=100_000,
+        cache_read_input_tokens=0,
+        cache_write_input_tokens=0,
+        pricing=pricing,
+        service_tier="priority",
+    )
+
+    assert cost == pytest.approx(0.90)
+
+
+def test_usage_metrics_prefers_response_service_tier() -> None:
+    pricing = ModelPricing(
+        0.30,
+        1.20,
+        pricing_tiers=(
+            ModelPricingTier("standard", 0.60, 2.40, input_tokens_gt=512_000),
+            ModelPricingTier("priority", 0.90, 3.60, input_tokens_gt=512_000),
+        ),
+    )
+    content = json.dumps({
+        "service_tier": "priority",
+        "usage": {
+            "prompt_tokens": 600_000,
+            "completion_tokens": 100_000,
+            "total_tokens": 700_000,
+        },
+    }).encode()
+
+    usage = parse_usage_metrics(
+        content,
+        "test/model",
+        {"test/model": pricing},
+    )
+
+    assert usage is not None
+    assert usage.actual_cost == pytest.approx(0.90)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -61,10 +61,10 @@ class TestProviderConfig:
 
     def test_minimax_provider_model_metadata(self) -> None:
         m3_pricing = PROVIDER_MODEL_PRICING["minimax/minimax-m3"]
-        assert m3_pricing.for_usage(512_000).input_price == 0.30
-        assert m3_pricing.for_usage(512_001).input_price == 0.60
-        assert m3_pricing.for_usage(512_000, "priority").input_price == 0.45
-        assert m3_pricing.for_usage(512_001, "priority").input_price == 0.90
+        assert m3_pricing.input_price == 0.60
+        assert m3_pricing.output_price == 2.40
+        assert m3_pricing.cached_input_price == 0.12
+        assert m3_pricing.cache_write_price is None
 
         m27_pricing = PROVIDER_MODEL_PRICING["minimax/minimax-m2.7"]
         assert m27_pricing.cached_input_price == 0.06

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -11,6 +11,7 @@ from uncommon_route.providers import (
     ProviderEntry,
     add_provider,
     load_providers,
+    resolve_upstream_model,
     remove_provider,
     select_preferred_model,
 )
@@ -50,6 +51,11 @@ class TestProviderConfig:
     def test_add_provider_custom_url(self) -> None:
         cfg = add_provider("openai", "sk-openai", base_url="https://my-proxy.com/v1")
         assert cfg.providers["openai"].base_url == "https://my-proxy.com/v1"
+
+    def test_resolve_minimax_upstream_model_ids(self) -> None:
+        assert resolve_upstream_model("minimax", "minimax/minimax-m3") == "MiniMax-M3"
+        assert resolve_upstream_model("minimax", "minimax/minimax-m2.7") == "MiniMax-M2.7"
+        assert resolve_upstream_model("minimax", "minimax/unknown") == "minimax/unknown"
 
     def test_add_provider_custom_models(self) -> None:
         cfg = add_provider(

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -15,6 +15,7 @@ from uncommon_route.providers import (
     remove_provider,
     select_preferred_model,
 )
+from uncommon_route.router.config import PROVIDER_MODEL_CAPABILITIES, PROVIDER_MODEL_PRICING
 from uncommon_route.router.types import RoutingFeatures, Tier
 
 
@@ -53,9 +54,35 @@ class TestProviderConfig:
         assert cfg.providers["openai"].base_url == "https://my-proxy.com/v1"
 
     def test_resolve_minimax_upstream_model_ids(self) -> None:
+        assert resolve_upstream_model("minimax", "minimax/minimax-m2.5") == "MiniMax-M2.5"
         assert resolve_upstream_model("minimax", "minimax/minimax-m3") == "MiniMax-M3"
         assert resolve_upstream_model("minimax", "minimax/minimax-m2.7") == "MiniMax-M2.7"
         assert resolve_upstream_model("minimax", "minimax/unknown") == "minimax/unknown"
+
+    def test_minimax_provider_model_metadata(self) -> None:
+        m3_pricing = PROVIDER_MODEL_PRICING["minimax/minimax-m3"]
+        assert m3_pricing.for_usage(512_000).input_price == 0.30
+        assert m3_pricing.for_usage(512_001).input_price == 0.60
+        assert m3_pricing.for_usage(512_000, "priority").input_price == 0.45
+        assert m3_pricing.for_usage(512_001, "priority").input_price == 0.90
+
+        m27_pricing = PROVIDER_MODEL_PRICING["minimax/minimax-m2.7"]
+        assert m27_pricing.cached_input_price == 0.06
+        assert m27_pricing.cache_write_price == 0.375
+
+        m3_capabilities = PROVIDER_MODEL_CAPABILITIES["minimax/minimax-m3"]
+        assert m3_capabilities.context_window == 1_000_000
+        assert m3_capabilities.input_modalities == ("text", "image", "video")
+        assert m3_capabilities.thinking_modes == ("adaptive", "disabled")
+        assert m3_capabilities.vision is True
+        assert m3_capabilities.reasoning is True
+
+        m27_capabilities = PROVIDER_MODEL_CAPABILITIES["minimax/minimax-m2.7"]
+        assert m27_capabilities.context_window == 204_800
+        assert m27_capabilities.input_modalities == ("text",)
+        assert m27_capabilities.thinking_modes == ("always_on",)
+        assert m27_capabilities.vision is False
+        assert m27_capabilities.reasoning is True
 
     def test_add_provider_custom_models(self) -> None:
         cfg = add_provider(

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -41,7 +41,11 @@ class TestProviderConfig:
         cfg = add_provider("minimax", "eyJ-test", plan="coding-plan")
         entry = cfg.providers["minimax"]
         assert entry.plan == "coding-plan"
-        assert "minimax/minimax-m2.5" in entry.models
+        assert entry.models == [
+            "minimax/minimax-m2.5",
+            "minimax/minimax-m3",
+            "minimax/minimax-m2.7",
+        ]
 
     def test_add_provider_custom_url(self) -> None:
         cfg = add_provider("openai", "sk-openai", base_url="https://my-proxy.com/v1")

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -114,6 +114,16 @@ class TestProviderModelMetadata:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         routed: dict[str, object] = {}
+        estimated_tiers: list[str] = []
+
+        def fake_estimate_cost(
+            _model: str,
+            _input_tokens: int,
+            _output_tokens: int,
+            service_tier: str = "standard",
+        ) -> float:
+            estimated_tiers.append(service_tier)
+            return 0.001
 
         def fake_route(*_args, **kwargs) -> RoutingDecision:
             routed["pricing"] = kwargs["pricing"]
@@ -167,6 +177,7 @@ class TestProviderModelMetadata:
         })
         async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
         monkeypatch.setattr("uncommon_route.proxy._get_client", lambda: async_client)
+        monkeypatch.setattr("uncommon_route.proxy._estimate_cost", fake_estimate_cost)
         monkeypatch.setattr("uncommon_route.proxy.route", fake_route)
 
         try:
@@ -178,6 +189,7 @@ class TestProviderModelMetadata:
             client = TestClient(app, raise_server_exceptions=False)
             resp = client.post("/v1/chat/completions", json={
                 "model": "uncommon-route/auto",
+                "service_tier": "priority",
                 "messages": [{"role": "user", "content": "describe this image"}],
             })
 
@@ -191,6 +203,8 @@ class TestProviderModelMetadata:
             assert capabilities["minimax/minimax-m3"].vision is True
             assert capabilities["minimax/minimax-m2.7"].thinking_modes == ("always_on",)
             assert captured["body"]["model"] == "MiniMax-M3"
+            assert captured["body"]["service_tier"] == "priority"
+            assert "priority" in estimated_tiers
         finally:
             asyncio.run(async_client.aclose())
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -92,7 +92,7 @@ class TestUpstreamSemanticCompressor:
             upstream_chat="https://primary.example/v1/chat/completions",
             primary_api_key="primary-test-key",
             providers_config=providers,
-            model_mapper=_build_test_mapper("openai/gpt-4o-mini"),
+            model_mapper=ModelMapper("https://primary.example/v1"),
             composition_policy=CompositionPolicy(),
         )
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -17,6 +17,7 @@ from uncommon_route.model_map import DiscoveredModel, ModelMapper
 from uncommon_route.model_experience import InMemoryModelExperienceStorage, ModelExperienceStore
 from uncommon_route.providers import ProviderEntry, ProvidersConfig
 from uncommon_route.proxy import (
+    UpstreamSemanticCompressor,
     _extract_current_message,
     _extract_prompt,
     _normalize_reasoning_content_chunk,
@@ -75,6 +76,36 @@ def _build_test_mapper(*model_ids: str) -> ModelMapper:
         mapper._upstream_models.add(model_id)
     mapper._discovered = True
     return mapper
+
+
+class TestUpstreamSemanticCompressor:
+    def test_direct_minimax_provider_uses_upstream_model_id(self) -> None:
+        providers = ProvidersConfig(providers={
+            "minimax": ProviderEntry(
+                name="minimax",
+                api_key="test-key",
+                base_url="https://api.minimax.io/v1",
+                models=["minimax/minimax-m3"],
+            ),
+        })
+        compressor = UpstreamSemanticCompressor(
+            upstream_chat="https://primary.example/v1/chat/completions",
+            primary_api_key="primary-test-key",
+            providers_config=providers,
+            model_mapper=_build_test_mapper("openai/gpt-4o-mini"),
+            composition_policy=CompositionPolicy(),
+        )
+
+        resolved = compressor._resolve_request(
+            "minimax/minimax-m3",
+            httpx.Request("POST", "https://local.example/v1/chat/completions"),
+        )
+
+        assert resolved is not None
+        target_url, headers, upstream_model = resolved
+        assert target_url == "https://api.minimax.io/v1/chat/completions"
+        assert headers["authorization"] == "Bearer test-key"
+        assert upstream_model == "MiniMax-M3"
 
 
 class TestPromptExtraction:

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -198,7 +198,10 @@ class TestProviderModelMetadata:
             capabilities = routed["capabilities"]
             assert isinstance(pricing, dict)
             assert isinstance(capabilities, dict)
-            assert pricing["minimax/minimax-m3"].cached_input_price == 0.06
+            assert pricing["minimax/minimax-m3"].input_price == 0.60
+            assert pricing["minimax/minimax-m3"].output_price == 2.40
+            assert pricing["minimax/minimax-m3"].cached_input_price == 0.12
+            assert pricing["minimax/minimax-m3"].cache_write_price is None
             assert pricing["minimax/minimax-m2.7"].cache_write_price == 0.375
             assert capabilities["minimax/minimax-m3"].vision is True
             assert capabilities["minimax/minimax-m2.7"].thinking_modes == ("always_on",)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -108,6 +108,93 @@ class TestUpstreamSemanticCompressor:
         assert upstream_model == "MiniMax-M3"
 
 
+class TestProviderModelMetadata:
+    def test_minimax_byok_metadata_is_available_to_virtual_routing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        routed: dict[str, object] = {}
+
+        def fake_route(*_args, **kwargs) -> RoutingDecision:
+            routed["pricing"] = kwargs["pricing"]
+            routed["capabilities"] = kwargs["model_capabilities"]
+            return RoutingDecision(
+                model="minimax/minimax-m3",
+                tier=Tier.COMPLEX,
+                capability_lane=CapabilityLane.VISION,
+                served_quality=ServedQuality.PREMIUM,
+                served_quality_target=ServedQuality.PREMIUM,
+                served_quality_floor=ServedQuality.PREMIUM,
+                continuity_quality_floor=kwargs["routing_features"].continuity_quality_floor,
+                mode=RoutingMode.AUTO,
+                confidence=0.9,
+                method="provider metadata test",
+                reasoning="provider metadata test",
+                cost_estimate=0.001,
+                baseline_cost=0.002,
+                savings=0.5,
+                routing_features=kwargs["routing_features"],
+            )
+
+        captured: dict[str, object] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode("utf-8"))
+            return httpx.Response(
+                200,
+                json={
+                    "id": "chatcmpl_minimax_metadata",
+                    "object": "chat.completion",
+                    "created": 1,
+                    "model": "MiniMax-M3",
+                    "choices": [{
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+                },
+                headers={"content-type": "application/json"},
+            )
+
+        providers = ProvidersConfig(providers={
+            "minimax": ProviderEntry(
+                name="minimax",
+                api_key="test-key",
+                base_url="https://api.minimax.io/v1",
+                models=["minimax/minimax-m3", "minimax/minimax-m2.7"],
+            ),
+        })
+        async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        monkeypatch.setattr("uncommon_route.proxy._get_client", lambda: async_client)
+        monkeypatch.setattr("uncommon_route.proxy.route", fake_route)
+
+        try:
+            app = create_app(
+                upstream="https://primary.example/v1",
+                providers_config=providers,
+                spend_control=SpendControl(storage=InMemorySpendControlStorage()),
+            )
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.post("/v1/chat/completions", json={
+                "model": "uncommon-route/auto",
+                "messages": [{"role": "user", "content": "describe this image"}],
+            })
+
+            assert resp.status_code == 200
+            pricing = routed["pricing"]
+            capabilities = routed["capabilities"]
+            assert isinstance(pricing, dict)
+            assert isinstance(capabilities, dict)
+            assert pricing["minimax/minimax-m3"].cached_input_price == 0.06
+            assert pricing["minimax/minimax-m2.7"].cache_write_price == 0.375
+            assert capabilities["minimax/minimax-m3"].vision is True
+            assert capabilities["minimax/minimax-m2.7"].thinking_modes == ("always_on",)
+            assert captured["body"]["model"] == "MiniMax-M3"
+        finally:
+            asyncio.run(async_client.aclose())
+
+
 class TestPromptExtraction:
     def test_extract_prompt_ignores_claude_code_wrapper_blocks(self) -> None:
         prompt, system_prompt, max_tokens = _extract_prompt({

--- a/uncommon_route/cache_support.py
+++ b/uncommon_route/cache_support.py
@@ -268,6 +268,7 @@ def parse_usage_metrics(
     actual_cost: float | None = None
     input_cost_multiplier = 1.0
     if mp is not None:
+        effective_pricing = mp.for_usage(input_tokens_total)
         actual_cost = estimate_usage_cost(
             input_tokens_uncached=input_tokens_uncached,
             output_tokens=output_tokens,
@@ -275,7 +276,7 @@ def parse_usage_metrics(
             cache_write_input_tokens=cache_write_input_tokens,
             pricing=mp,
         )
-        baseline_input_cost = (input_tokens_total / 1_000_000) * mp.input_price
+        baseline_input_cost = (input_tokens_total / 1_000_000) * effective_pricing.input_price
         effective_input_cost = estimate_input_cost(
             input_tokens_uncached=input_tokens_uncached,
             cache_read_input_tokens=cache_read_input_tokens,
@@ -411,6 +412,8 @@ def estimate_input_cost(
     cache_write_input_tokens: int,
     pricing: ModelPricing,
 ) -> float:
+    total_input_tokens = input_tokens_uncached + cache_read_input_tokens + cache_write_input_tokens
+    pricing = pricing.for_usage(total_input_tokens)
     cached_read_price = (
         pricing.cached_input_price
         if pricing.cached_input_price is not None
@@ -436,6 +439,8 @@ def estimate_usage_cost(
     cache_write_input_tokens: int,
     pricing: ModelPricing,
 ) -> float:
+    total_input_tokens = input_tokens_uncached + cache_read_input_tokens + cache_write_input_tokens
+    pricing = pricing.for_usage(total_input_tokens)
     return estimate_input_cost(
         input_tokens_uncached=input_tokens_uncached,
         cache_read_input_tokens=cache_read_input_tokens,

--- a/uncommon_route/cache_support.py
+++ b/uncommon_route/cache_support.py
@@ -205,6 +205,7 @@ def parse_usage_metrics(
     content: bytes,
     model: str,
     pricing: dict[str, ModelPricing],
+    service_tier: str = "standard",
 ) -> UsageMetrics | None:
     try:
         data = json.loads(content)
@@ -214,6 +215,9 @@ def parse_usage_metrics(
     usage = data.get("usage") or {}
     if not isinstance(usage, dict):
         return None
+    effective_service_tier = str(
+        data.get("service_tier") or usage.get("service_tier") or service_tier or "standard"
+    ).strip().lower()
 
     prompt_details = usage.get("prompt_tokens_details") or usage.get("input_tokens_details") or {}
     output_details = usage.get("completion_tokens_details") or usage.get("output_tokens_details") or {}
@@ -268,13 +272,14 @@ def parse_usage_metrics(
     actual_cost: float | None = None
     input_cost_multiplier = 1.0
     if mp is not None:
-        effective_pricing = mp.for_usage(input_tokens_total)
+        effective_pricing = mp.for_usage(input_tokens_total, effective_service_tier)
         actual_cost = estimate_usage_cost(
             input_tokens_uncached=input_tokens_uncached,
             output_tokens=output_tokens,
             cache_read_input_tokens=cache_read_input_tokens,
             cache_write_input_tokens=cache_write_input_tokens,
             pricing=mp,
+            service_tier=effective_service_tier,
         )
         baseline_input_cost = (input_tokens_total / 1_000_000) * effective_pricing.input_price
         effective_input_cost = estimate_input_cost(
@@ -282,6 +287,7 @@ def parse_usage_metrics(
             cache_read_input_tokens=cache_read_input_tokens,
             cache_write_input_tokens=cache_write_input_tokens,
             pricing=mp,
+            service_tier=effective_service_tier,
         )
         if baseline_input_cost > 0:
             input_cost_multiplier = max(0.05, min(2.0, effective_input_cost / baseline_input_cost))
@@ -318,6 +324,7 @@ def parse_stream_usage_metrics(
     chunks: list[bytes],
     model: str,
     pricing: dict[str, ModelPricing],
+    service_tier: str = "standard",
 ) -> UsageMetrics | None:
     if not chunks:
         return None
@@ -331,6 +338,7 @@ def parse_stream_usage_metrics(
     fallback_output_tokens = 0
     fallback_prompt_tokens = 0
     fallback_has_content = False
+    effective_service_tier = service_tier
 
     for line in text.splitlines():
         if not line.startswith("data:"):
@@ -342,9 +350,16 @@ def parse_stream_usage_metrics(
             data = json.loads(payload)
         except json.JSONDecodeError:
             continue
+        if isinstance(data, dict) and data.get("service_tier"):
+            effective_service_tier = str(data["service_tier"])
         if isinstance(data, dict) and isinstance(data.get("usage"), dict):
             anthropic_usage.update(data["usage"])
-            parsed = parse_usage_metrics(json.dumps({"usage": anthropic_usage}).encode("utf-8"), model, pricing)
+            parsed = parse_usage_metrics(
+                json.dumps({"usage": anthropic_usage}).encode("utf-8"),
+                model,
+                pricing,
+                effective_service_tier,
+            )
             if parsed is not None:
                 latest = parsed
             continue
@@ -353,6 +368,8 @@ def parse_stream_usage_metrics(
         message = data.get("message")
         if isinstance(message, dict) and isinstance(message.get("usage"), dict):
             anthropic_usage.update(message["usage"])
+        if isinstance(message, dict) and message.get("service_tier"):
+            effective_service_tier = str(message["service_tier"])
         if data.get("type") == "message_delta" and isinstance(data.get("usage"), dict):
             anthropic_usage.update(data["usage"])
         if anthropic_usage:
@@ -360,6 +377,7 @@ def parse_stream_usage_metrics(
                 json.dumps({"usage": anthropic_usage}).encode("utf-8"),
                 model,
                 pricing,
+                effective_service_tier,
             )
             if parsed is not None:
                 latest = parsed
@@ -388,6 +406,7 @@ def parse_stream_usage_metrics(
                 cache_read_input_tokens=0,
                 cache_write_input_tokens=0,
                 pricing=mp,
+                service_tier=effective_service_tier,
             )
         latest = UsageMetrics(
             input_tokens_total=fallback_prompt_tokens,
@@ -411,9 +430,10 @@ def estimate_input_cost(
     cache_read_input_tokens: int,
     cache_write_input_tokens: int,
     pricing: ModelPricing,
+    service_tier: str = "standard",
 ) -> float:
     total_input_tokens = input_tokens_uncached + cache_read_input_tokens + cache_write_input_tokens
-    pricing = pricing.for_usage(total_input_tokens)
+    pricing = pricing.for_usage(total_input_tokens, service_tier)
     cached_read_price = (
         pricing.cached_input_price
         if pricing.cached_input_price is not None
@@ -438,14 +458,16 @@ def estimate_usage_cost(
     cache_read_input_tokens: int,
     cache_write_input_tokens: int,
     pricing: ModelPricing,
+    service_tier: str = "standard",
 ) -> float:
     total_input_tokens = input_tokens_uncached + cache_read_input_tokens + cache_write_input_tokens
-    pricing = pricing.for_usage(total_input_tokens)
+    pricing = pricing.for_usage(total_input_tokens, service_tier)
     return estimate_input_cost(
         input_tokens_uncached=input_tokens_uncached,
         cache_read_input_tokens=cache_read_input_tokens,
         cache_write_input_tokens=cache_write_input_tokens,
         pricing=pricing,
+        service_tier=service_tier,
     ) + ((output_tokens / 1_000_000) * pricing.output_price)
 
 

--- a/uncommon_route/providers.py
+++ b/uncommon_route/providers.py
@@ -48,7 +48,7 @@ KNOWN_BASE_URLS: dict[str, str] = {
 }
 
 PROVIDER_MODELS: dict[str, list[str]] = {
-    "minimax": ["minimax/minimax-m2.5"],
+    "minimax": ["minimax/minimax-m2.5", "minimax/minimax-m3"],
     "deepseek": ["deepseek/deepseek-chat", "deepseek/deepseek-reasoner"],
     "openai": ["openai/gpt-4o-mini", "openai/gpt-4o", "openai/gpt-5.2", "openai/gpt-5.2-codex", "openai/o1-mini", "openai/o3", "openai/o4-mini"],
     "anthropic": ["anthropic/claude-haiku-4.5", "anthropic/claude-sonnet-4.6", "anthropic/claude-opus-4.6"],

--- a/uncommon_route/providers.py
+++ b/uncommon_route/providers.py
@@ -61,6 +61,17 @@ PROVIDER_MODELS: dict[str, list[str]] = {
     "moonshot": ["moonshot/kimi-k2.5"],
 }
 
+UPSTREAM_MODEL_IDS: dict[str, dict[str, str]] = {
+    "minimax": {
+        "minimax/minimax-m3": "MiniMax-M3",
+        "minimax/minimax-m2.7": "MiniMax-M2.7",
+    },
+}
+
+
+def resolve_upstream_model(provider_name: str, model_id: str) -> str:
+    return UPSTREAM_MODEL_IDS.get(provider_name, {}).get(model_id, model_id)
+
 
 @dataclass
 class ProviderEntry:

--- a/uncommon_route/providers.py
+++ b/uncommon_route/providers.py
@@ -63,6 +63,7 @@ PROVIDER_MODELS: dict[str, list[str]] = {
 
 UPSTREAM_MODEL_IDS: dict[str, dict[str, str]] = {
     "minimax": {
+        "minimax/minimax-m2.5": "MiniMax-M2.5",
         "minimax/minimax-m3": "MiniMax-M3",
         "minimax/minimax-m2.7": "MiniMax-M2.7",
     },

--- a/uncommon_route/providers.py
+++ b/uncommon_route/providers.py
@@ -12,7 +12,11 @@ Example (providers.json):
         "minimax": {
           "api_key": "eyJ...",
           "base_url": "https://api.minimax.io/v1",
-          "models": ["minimax/minimax-m2.5"],
+          "models": [
+            "minimax/minimax-m2.5",
+            "minimax/minimax-m3",
+            "minimax/minimax-m2.7"
+          ],
           "plan": "coding-plan"
         },
         "deepseek": {

--- a/uncommon_route/providers.py
+++ b/uncommon_route/providers.py
@@ -48,7 +48,7 @@ KNOWN_BASE_URLS: dict[str, str] = {
 }
 
 PROVIDER_MODELS: dict[str, list[str]] = {
-    "minimax": ["minimax/minimax-m2.5", "minimax/minimax-m3"],
+    "minimax": ["minimax/minimax-m2.5", "minimax/minimax-m3", "minimax/minimax-m2.7"],
     "deepseek": ["deepseek/deepseek-chat", "deepseek/deepseek-reasoner"],
     "openai": ["openai/gpt-4o-mini", "openai/gpt-4o", "openai/gpt-5.2", "openai/gpt-5.2-codex", "openai/o1-mini", "openai/o3", "openai/o4-mini"],
     "anthropic": ["anthropic/claude-haiku-4.5", "anthropic/claude-sonnet-4.6", "anthropic/claude-opus-4.6"],

--- a/uncommon_route/proxy.py
+++ b/uncommon_route/proxy.py
@@ -915,7 +915,7 @@ class UpstreamSemanticCompressor:
         provider_entry = self._providers.get_for_model(model_id)
         if provider_entry and provider_entry.base_url:
             target_chat_url = f"{provider_entry.base_url.rstrip('/')}/chat/completions"
-            upstream_model = model_id
+            upstream_model = resolve_upstream_model(provider_entry.name, model_id)
         elif self._upstream_chat:
             target_chat_url = self._upstream_chat
             upstream_model = self._mapper.resolve(model_id)

--- a/uncommon_route/proxy.py
+++ b/uncommon_route/proxy.py
@@ -59,6 +59,8 @@ from uncommon_route.router.config import (
     BASELINE_MODEL,
     DEFAULT_CONFIG,
     DEFAULT_MODEL_PRICING,
+    PROVIDER_MODEL_CAPABILITIES,
+    PROVIDER_MODEL_PRICING,
     VIRTUAL_MODEL_IDS,
     routing_mode_from_model,
     virtual_model_entries,
@@ -321,6 +323,7 @@ def _estimate_cost(model: str, input_tokens: int, output_tokens: int) -> float:
     mp = _get_pricing().get(model)
     if mp is None:
         return 0.0
+    mp = mp.for_usage(input_tokens)
     return (input_tokens / 1_000_000) * mp.input_price + (output_tokens / 1_000_000) * mp.output_price
 
 
@@ -2847,6 +2850,11 @@ def create_app(
         dynamic = _mapper.dynamic_pricing
         if dynamic:
             merged.update(dynamic)
+        keyed_models = _providers.keyed_models()
+        for model_id in keyed_models:
+            provider_pricing = PROVIDER_MODEL_PRICING.get(model_id)
+            if provider_pricing is not None:
+                merged[model_id] = provider_pricing
         _active_pricing = merged
 
         import copy
@@ -2855,7 +2863,13 @@ def create_app(
         if dynamic_caps:
             merged_caps = dict(updated.model_capabilities)
             merged_caps.update(dynamic_caps)
-            updated.model_capabilities = merged_caps
+        else:
+            merged_caps = dict(updated.model_capabilities)
+        for model_id in keyed_models:
+            provider_capabilities = PROVIDER_MODEL_CAPABILITIES.get(model_id)
+            if provider_capabilities is not None:
+                merged_caps[model_id] = provider_capabilities
+        updated.model_capabilities = merged_caps
         _routing_config = updated
 
     def _reload_providers() -> ProvidersConfig:
@@ -2863,7 +2877,10 @@ def create_app(
         _providers = load_providers()
         if isinstance(_semantic, UpstreamSemanticCompressor):
             _semantic.rebind_providers(_providers)
+        _refresh_active_pricing()
         return _providers
+
+    _refresh_active_pricing()
 
     def _current_connection_payload() -> dict[str, Any]:
         effective = resolve_primary_connection(

--- a/uncommon_route/proxy.py
+++ b/uncommon_route/proxy.py
@@ -318,12 +318,17 @@ def _get_pricing() -> dict[str, ModelPricing]:
     return _active_pricing or DEFAULT_MODEL_PRICING
 
 
-def _estimate_cost(model: str, input_tokens: int, output_tokens: int) -> float:
+def _estimate_cost(
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    service_tier: str = "standard",
+) -> float:
     """Compute dollar cost from token counts using the model pricing table."""
     mp = _get_pricing().get(model)
     if mp is None:
         return 0.0
-    mp = mp.for_usage(input_tokens)
+    mp = mp.for_usage(input_tokens, service_tier)
     return (input_tokens / 1_000_000) * mp.input_price + (output_tokens / 1_000_000) * mp.output_price
 
 
@@ -3952,6 +3957,7 @@ def create_app(
 
         model = (body.get("model") or "").strip().lower()
         is_streaming = body.get("stream", False)
+        request_service_tier = str(body.get("service_tier") or "standard").strip().lower()
         response_model = str(body.pop("_client_requested_model", "") or model).strip()
         recursion_guarded = _recursion_guard_enabled(request)
 
@@ -4164,6 +4170,7 @@ def create_app(
                         _active_scene.primary,
                         input_token_estimate,
                         scene_output_budget,
+                        request_service_tier,
                     )
                     scene_baseline = _estimate_baseline_cost(
                         input_token_estimate,
@@ -4421,6 +4428,7 @@ def create_app(
                 selected_model,
                 input_tokens_after,
                 effective_output_tokens,
+                request_service_tier,
             )
             baseline_cost = _estimate_baseline_cost(
                 input_tokens_before if input_tokens_before > 0 else input_tokens_after,
@@ -4578,7 +4586,12 @@ def create_app(
             full_text = f"{system_prompt or ''} {prompt}".strip()
             input_tokens_before = estimate_tokens(full_text) if full_text else 0
             input_tokens_after = input_tokens_before
-            estimated_cost = _estimate_cost(selected_model, input_tokens_after, max_tokens)
+            estimated_cost = _estimate_cost(
+                selected_model,
+                input_tokens_after,
+                max_tokens,
+                request_service_tier,
+            )
             baseline_cost = estimated_cost
             main_estimated_cost = estimated_cost
             effective_output_tokens = max_tokens
@@ -4618,7 +4631,12 @@ def create_app(
 
         def _estimated_total_cost_for(model_name: str) -> tuple[float, float]:
             token_input = input_tokens_after if input_tokens_after > 0 else input_tokens_before
-            main_cost = _estimate_cost(model_name, token_input, effective_output_tokens)
+            main_cost = _estimate_cost(
+                model_name,
+                token_input,
+                effective_output_tokens,
+                request_service_tier,
+            )
             total_cost = main_cost + (sidechannel_estimated_cost if is_virtual else 0.0)
             return main_cost, total_cost
 
@@ -5630,7 +5648,12 @@ def create_app(
                                 for ev in converter.finish():
                                     yield ev
                             await _record_stream_success(
-                                parse_stream_usage_metrics(stream_chunks, selected_model, _get_pricing()),
+                                parse_stream_usage_metrics(
+                                    stream_chunks,
+                                    selected_model,
+                                    _get_pricing(),
+                                    request_service_tier,
+                                ),
                                 stream_chunks=stream_chunks,
                             )
                         except Exception:
@@ -5669,7 +5692,12 @@ def create_app(
                             for ev in converter.finish():
                                 yield ev
                             await _record_stream_success(
-                                parse_stream_usage_metrics(stream_chunks, selected_model, _get_pricing()),
+                                parse_stream_usage_metrics(
+                                    stream_chunks,
+                                    selected_model,
+                                    _get_pricing(),
+                                    request_service_tier,
+                                ),
                                 stream_chunks=stream_chunks,
                             )
                         except Exception:
@@ -5697,7 +5725,12 @@ def create_app(
                             _mark_current_attempt_first_token()
                             yield _normalize_reasoning_content_chunk(chunk)
                         await _record_stream_success(
-                            parse_stream_usage_metrics(stream_chunks, selected_model, _get_pricing()),
+                            parse_stream_usage_metrics(
+                                stream_chunks,
+                                selected_model,
+                                _get_pricing(),
+                                request_service_tier,
+                            ),
                             stream_chunks=stream_chunks,
                         )
                     except Exception:
@@ -5771,7 +5804,12 @@ def create_app(
             tps: float | None = None
             usage_metrics: UsageMetrics | None = None
             if resp.status_code == 200:
-                usage_metrics = parse_usage_metrics(resp.content, selected_model, _get_pricing())
+                usage_metrics = parse_usage_metrics(
+                    resp.content,
+                    selected_model,
+                    _get_pricing(),
+                    request_service_tier,
+                )
                 if usage_metrics is not None:
                     actual_cost = (
                         usage_metrics.actual_cost

--- a/uncommon_route/proxy.py
+++ b/uncommon_route/proxy.py
@@ -106,6 +106,7 @@ from uncommon_route.providers import (
     ProvidersConfig,
     add_provider,
     load_providers,
+    resolve_upstream_model,
     remove_provider,
     verify_key,
 )
@@ -4635,7 +4636,9 @@ def create_app(
                     attempt_headers[_ORIGINAL_MODEL_HEADER] = requested_model
 
             resolved_model = model_name
-            if not attempt_provider_entry:
+            if attempt_provider_entry:
+                resolved_model = resolve_upstream_model(attempt_provider_entry.name, model_name)
+            else:
                 resolved_model = _mapper.resolve(model_name)
             attempt_upstream_body["model"] = resolved_model
 

--- a/uncommon_route/router/config.py
+++ b/uncommon_route/router/config.py
@@ -6,6 +6,7 @@ from uncommon_route.router.types import (
     ModeConfig,
     ModelCapabilities,
     ModelPricing,
+    ModelPricingTier,
     RoutingConfig,
     RoutingMode,
     ScoringConfig,
@@ -40,6 +41,68 @@ DEFAULT_MODEL_PRICING: dict[str, ModelPricing] = {
     "anthropic/claude-sonnet-4.6": ModelPricing(3.00, 15.00, cached_input_price=0.30, cache_write_price=3.75),
     "anthropic/claude-opus-4.6": ModelPricing(5.00, 25.00, cached_input_price=0.50, cache_write_price=6.25),
     "anthropic/claude-opus-4-7": ModelPricing(5.00, 25.00, cached_input_price=0.50, cache_write_price=6.25),
+}
+
+PROVIDER_MODEL_PRICING: dict[str, ModelPricing] = {
+    "minimax/minimax-m3": ModelPricing(
+        0.30,
+        1.20,
+        cached_input_price=0.06,
+        pricing_tiers=(
+            ModelPricingTier(
+                service_tier="standard",
+                input_tokens_lte=512_000,
+                input_price=0.30,
+                output_price=1.20,
+                cached_input_price=0.06,
+            ),
+            ModelPricingTier(
+                service_tier="standard",
+                input_tokens_gt=512_000,
+                input_price=0.60,
+                output_price=2.40,
+                cached_input_price=0.12,
+            ),
+            ModelPricingTier(
+                service_tier="priority",
+                input_tokens_lte=512_000,
+                input_price=0.45,
+                output_price=1.80,
+                cached_input_price=0.09,
+            ),
+            ModelPricingTier(
+                service_tier="priority",
+                input_tokens_gt=512_000,
+                input_price=0.90,
+                output_price=3.60,
+                cached_input_price=0.18,
+            ),
+        ),
+    ),
+    "minimax/minimax-m2.7": ModelPricing(
+        0.30,
+        1.20,
+        cached_input_price=0.06,
+        cache_write_price=0.375,
+    ),
+}
+
+PROVIDER_MODEL_CAPABILITIES: dict[str, ModelCapabilities] = {
+    "minimax/minimax-m3": ModelCapabilities(
+        tool_calling=True,
+        vision=True,
+        reasoning=True,
+        context_window=1_000_000,
+        input_modalities=("text", "image", "video"),
+        thinking_modes=("adaptive", "disabled"),
+    ),
+    "minimax/minimax-m2.7": ModelCapabilities(
+        tool_calling=True,
+        reasoning=True,
+        context_window=204_800,
+        input_modalities=("text",),
+        thinking_modes=("always_on",),
+    ),
 }
 
 BASELINE_MODEL = "anthropic/claude-opus-4-7"

--- a/uncommon_route/router/config.py
+++ b/uncommon_route/router/config.py
@@ -6,7 +6,6 @@ from uncommon_route.router.types import (
     ModeConfig,
     ModelCapabilities,
     ModelPricing,
-    ModelPricingTier,
     RoutingConfig,
     RoutingMode,
     ScoringConfig,
@@ -45,39 +44,9 @@ DEFAULT_MODEL_PRICING: dict[str, ModelPricing] = {
 
 PROVIDER_MODEL_PRICING: dict[str, ModelPricing] = {
     "minimax/minimax-m3": ModelPricing(
-        0.30,
-        1.20,
-        cached_input_price=0.06,
-        pricing_tiers=(
-            ModelPricingTier(
-                service_tier="standard",
-                input_tokens_lte=512_000,
-                input_price=0.30,
-                output_price=1.20,
-                cached_input_price=0.06,
-            ),
-            ModelPricingTier(
-                service_tier="standard",
-                input_tokens_gt=512_000,
-                input_price=0.60,
-                output_price=2.40,
-                cached_input_price=0.12,
-            ),
-            ModelPricingTier(
-                service_tier="priority",
-                input_tokens_lte=512_000,
-                input_price=0.45,
-                output_price=1.80,
-                cached_input_price=0.09,
-            ),
-            ModelPricingTier(
-                service_tier="priority",
-                input_tokens_gt=512_000,
-                input_price=0.90,
-                output_price=3.60,
-                cached_input_price=0.18,
-            ),
-        ),
+        0.60,
+        2.40,
+        cached_input_price=0.12,
     ),
     "minimax/minimax-m2.7": ModelPricing(
         0.30,

--- a/uncommon_route/router/selector.py
+++ b/uncommon_route/router/selector.py
@@ -94,7 +94,7 @@ def _calc_cost(
     *,
     input_cost_multiplier: float = 1.0,
 ) -> float:
-    mp = _pricing_for_model(model, pricing)
+    mp = _pricing_for_model(model, pricing).for_usage(input_tokens)
     effective_multiplier = max(0.1, min(2.0, input_cost_multiplier))
     return (
         (input_tokens / 1_000_000) * mp.input_price * effective_multiplier

--- a/uncommon_route/router/types.py
+++ b/uncommon_route/router/types.py
@@ -60,6 +60,9 @@ class ModelCapabilities:
     free: bool = False
     local: bool = False
     responses: bool = False
+    context_window: int | None = None
+    input_modalities: tuple[str, ...] = ()
+    thinking_modes: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -417,11 +420,44 @@ class TierConfig:
 
 
 @dataclass(frozen=True, slots=True)
+class ModelPricingTier:
+    service_tier: str
+    input_price: float
+    output_price: float
+    cached_input_price: float | None = None
+    cache_write_price: float | None = None
+    input_tokens_lte: int | None = None
+    input_tokens_gt: int | None = None
+
+    def matches(self, input_tokens: int, service_tier: str) -> bool:
+        if self.service_tier != service_tier:
+            return False
+        if self.input_tokens_lte is not None and input_tokens > self.input_tokens_lte:
+            return False
+        if self.input_tokens_gt is not None and input_tokens <= self.input_tokens_gt:
+            return False
+        return True
+
+
+@dataclass(frozen=True, slots=True)
 class ModelPricing:
     input_price: float  # per 1M tokens
     output_price: float  # per 1M tokens
     cached_input_price: float | None = None  # per 1M cached-read tokens
     cache_write_price: float | None = None  # per 1M cache-write / cache-create tokens
+    pricing_tiers: tuple[ModelPricingTier, ...] = ()
+
+    def for_usage(self, input_tokens: int, service_tier: str = "standard") -> ModelPricing:
+        normalized_tier = str(service_tier or "standard").strip().lower()
+        for tier in self.pricing_tiers:
+            if tier.matches(max(0, input_tokens), normalized_tier):
+                return ModelPricing(
+                    input_price=tier.input_price,
+                    output_price=tier.output_price,
+                    cached_input_price=tier.cached_input_price,
+                    cache_write_price=tier.cache_write_price,
+                )
+        return self
 
 
 @dataclass(frozen=True, slots=True)

--- a/uncommon_route/router/types.py
+++ b/uncommon_route/router/types.py
@@ -449,14 +449,19 @@ class ModelPricing:
 
     def for_usage(self, input_tokens: int, service_tier: str = "standard") -> ModelPricing:
         normalized_tier = str(service_tier or "standard").strip().lower()
-        for tier in self.pricing_tiers:
-            if tier.matches(max(0, input_tokens), normalized_tier):
-                return ModelPricing(
-                    input_price=tier.input_price,
-                    output_price=tier.output_price,
-                    cached_input_price=tier.cached_input_price,
-                    cache_write_price=tier.cache_write_price,
-                )
+        available_tiers = {tier.service_tier for tier in self.pricing_tiers}
+        tier_candidates = [normalized_tier]
+        if normalized_tier not in available_tiers and "standard" in available_tiers:
+            tier_candidates.append("standard")
+        for tier_name in tier_candidates:
+            for tier in self.pricing_tiers:
+                if tier.matches(max(0, input_tokens), tier_name):
+                    return ModelPricing(
+                        input_price=tier.input_price,
+                        output_price=tier.output_price,
+                        cached_input_price=tier.cached_input_price,
+                        cache_write_price=tier.cache_write_price,
+                    )
         return self
 
 

--- a/uncommon_route/stats.py
+++ b/uncommon_route/stats.py
@@ -256,6 +256,8 @@ def _cache_savings(r: RouteRecord) -> float:
     pricing = _get_stats_pricing().get(r.model)
     if pricing is None:
         return 0.0
+    billed_input_tokens = r.usage_input_tokens or r.input_tokens_after
+    pricing = pricing.for_usage(billed_input_tokens)
     cached_input_price = pricing.cached_input_price if pricing.cached_input_price is not None else pricing.input_price
     cache_write_price = pricing.cache_write_price if pricing.cache_write_price is not None else pricing.input_price
     read_delta = ((pricing.input_price - cached_input_price) * r.cache_read_input_tokens) / 1_000_000
@@ -269,8 +271,11 @@ def _compaction_savings(r: RouteRecord) -> float:
     pricing = _get_stats_pricing().get(r.model)
     if pricing is None:
         return 0.0
-    reduced_tokens = r.input_tokens_before - r.input_tokens_after
-    return (reduced_tokens / 1_000_000) * pricing.input_price
+    before_pricing = pricing.for_usage(r.input_tokens_before)
+    after_pricing = pricing.for_usage(r.input_tokens_after)
+    before_cost = (r.input_tokens_before / 1_000_000) * before_pricing.input_price
+    after_cost = (r.input_tokens_after / 1_000_000) * after_pricing.input_price
+    return max(0.0, before_cost - after_cost)
 
 
 class RouteStats:


### PR DESCRIPTION
## Summary
- Add `minimax/minimax-m3` and `minimax/minimax-m2.7` to the default MiniMax BYOK provider model list.
- Keep the embedded provider configuration example and provider tests aligned with the defaults.
- Document the global and China OpenAI-compatible and Anthropic-compatible endpoints.
- Translate repository-facing model IDs for direct OpenAI, Anthropic, and semantic side-channel requests.
- Apply provider-specific context, modality, thinking, cache, and tiered pricing metadata during BYOK routing.

## Test plan
- `uv run --frozen --extra dev pytest -q`
- `uv run --frozen --extra dev ruff check uncommon_route/providers.py uncommon_route/proxy.py uncommon_route/cache_support.py uncommon_route/stats.py uncommon_route/router/config.py uncommon_route/router/selector.py uncommon_route/router/types.py tests/test_cache_support.py tests/test_providers.py tests/test_proxy.py tests/test_anthropic_compat.py`
